### PR TITLE
Terraform plugin sdk v2

### DIFF
--- a/internal/resources/computerextensionattributes/computerextensionattributes_data_validation.go
+++ b/internal/resources/computerextensionattributes/computerextensionattributes_data_validation.go
@@ -23,9 +23,9 @@ func validateDataType(val interface{}, key string) (warns []string, errs []error
 	return
 }
 
-// validateResourceComputerExtensionAttributesDataFields performs custom validation on the Resource's schema so that passed values from
+// validateJamfProRResourceComputerExtensionAttributesDataFields performs custom validation on the Resource's schema so that passed values from
 // teraform resource declarations align with attibute combinations supported by the Jamf Pro api.
-func validateResourceComputerExtensionAttributesDataFields(ctx context.Context, diff *schema.ResourceDiff, v interface{}) error {
+func validateJamfProRResourceComputerExtensionAttributesDataFields(ctx context.Context, diff *schema.ResourceDiff, v interface{}) error {
 	// Extract the first item from the input_type list, which should be a map
 	inputTypes, ok := diff.GetOk("input_type")
 	if !ok || len(inputTypes.([]interface{})) == 0 {

--- a/internal/resources/computerextensionattributes/computerextensionattributes_resource.go
+++ b/internal/resources/computerextensionattributes/computerextensionattributes_resource.go
@@ -26,7 +26,7 @@ func ResourceJamfProComputerExtensionAttributes() *schema.Resource {
 		ReadContext:   ResourceJamfProComputerExtensionAttributesRead,
 		UpdateContext: ResourceJamfProComputerExtensionAttributesUpdate,
 		DeleteContext: ResourceJamfProComputerExtensionAttributesDelete,
-		CustomizeDiff: validateResourceComputerExtensionAttributesDataFields,
+		CustomizeDiff: validateJamfProRResourceComputerExtensionAttributesDataFields,
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(1 * time.Minute),
 			Read:   schema.DefaultTimeout(1 * time.Minute),

--- a/internal/resources/policies/policies_data_validation.go
+++ b/internal/resources/policies/policies_data_validation.go
@@ -8,19 +8,26 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-// validateJamfProResourcePolicyDataFields ensures that a Jamf Pro policy is not set
-// to have an ongoing frequency when the trigger_checkin is true and it applies to all computers.
-// This function is intended to be used as a CustomizeDiff function in a Terraform resource schema
-// to validate the policy configuration during the plan phase.
+// validateJamfProResourcePolicyDataFields ensures that a Jamf Pro policy meets specific criteria:
+// 1. It cannot be set to have an ongoing frequency when the trigger_checkin is true and it applies to all computers.
+// 2. The 'offline' field can only be set to true if the 'frequency' is "Ongoing".
+// This function is used as a CustomizeDiff function in a Terraform resource schema to validate the policy configuration.
 func validateJamfProResourcePolicyDataFields(ctx context.Context, diff *schema.ResourceDiff, v interface{}) error {
+	// Validate the first scenario
 	triggerCheckin, triggerCheckinOk := diff.GetOk("general.0.trigger_checkin")
 	frequency, frequencyOk := diff.GetOk("general.0.frequency")
 	allComputers, allComputersOk := diff.GetOk("scope.0.all_computers")
 
 	if triggerCheckinOk && frequencyOk && allComputersOk {
 		if triggerCheckin.(bool) && frequency.(string) == "Ongoing" && allComputers.(bool) {
-			return fmt.Errorf("policies that update inventory on all computers cannot be set to ongoing frequency at recurring check-in")
+			return fmt.Errorf("jamf pro policies that update inventory on all computers cannot be set to ongoing frequency at recurring check-in. Please update your terraform configuration")
 		}
+	}
+
+	// Validate the second scenario
+	offline, offlineOk := diff.GetOk("general.0.offline")
+	if offlineOk && offline.(bool) && frequencyOk && frequency.(string) != "Ongoing" {
+		return fmt.Errorf("jamf pro policy triggers can only be set to 'offline' if the policy frequency is set to 'Ongoing'. Please update your terraform configuration")
 	}
 
 	return nil

--- a/internal/resources/policies/policies_data_validation.go
+++ b/internal/resources/policies/policies_data_validation.go
@@ -1,2 +1,27 @@
 // policies_data_validation.go
 package policies
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// validateJamfProResourcePolicyDataFields ensures that a Jamf Pro policy is not set
+// to have an ongoing frequency when the trigger_checkin is true and it applies to all computers.
+// This function is intended to be used as a CustomizeDiff function in a Terraform resource schema
+// to validate the policy configuration during the plan phase.
+func validateJamfProResourcePolicyDataFields(ctx context.Context, diff *schema.ResourceDiff, v interface{}) error {
+	triggerCheckin, triggerCheckinOk := diff.GetOk("general.0.trigger_checkin")
+	frequency, frequencyOk := diff.GetOk("general.0.frequency")
+	allComputers, allComputersOk := diff.GetOk("scope.0.all_computers")
+
+	if triggerCheckinOk && frequencyOk && allComputersOk {
+		if triggerCheckin.(bool) && frequency.(string) == "Ongoing" && allComputers.(bool) {
+			return fmt.Errorf("policies that update inventory on all computers cannot be set to ongoing frequency at recurring check-in")
+		}
+	}
+
+	return nil
+}

--- a/internal/resources/policies/policies_resource.go
+++ b/internal/resources/policies/policies_resource.go
@@ -160,7 +160,7 @@ func ResourceJamfProPolicies() *schema.Resource {
 						"offline": {
 							Type:        schema.TypeBool,
 							Optional:    true,
-							Description: "Whether the policy applies when offline.",
+							Description: "Make policy available offline by caching the policy to the macOS device to ensure it runs when Jamf Pro is unavailable. Only used when execution policy is set to 'ongoing'. ",
 							Default:     false,
 						},
 						"category": {

--- a/internal/resources/policies/policies_resource.go
+++ b/internal/resources/policies/policies_resource.go
@@ -25,6 +25,7 @@ func ResourceJamfProPolicies() *schema.Resource {
 		ReadContext:   ResourceJamfProPoliciesRead,
 		UpdateContext: ResourceJamfProPoliciesUpdate,
 		DeleteContext: ResourceJamfProPoliciesDelete,
+		CustomizeDiff: validateJamfProResourcePolicyDataFields,
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(1 * time.Minute),
 			Read:   schema.DefaultTimeout(1 * time.Minute),
@@ -957,7 +958,7 @@ func ResourceJamfProPolicies() *schema.Resource {
 							Type:        schema.TypeString,
 							Optional:    true,
 							Description: "Text displayed on the re-install button in self-service.",
-							Default:     "Reinstall",
+							Default:     "REINSTALL",
 						},
 						"self_service_description": {
 							Type:        schema.TypeString,


### PR DESCRIPTION
add scenarios for validateJamfProResourcePolicyDataFields to handle toxic (throw request conflict errors) , and handle impossible config combinations that aren't valid in the gui but don't throw a request conflict error.