### PR TITLE
Adding checks for Smart Groups

### DIFF
--- a/internal/endpoints/computergroups/computergroups_object.go
+++ b/internal/endpoints/computergroups/computergroups_object.go
@@ -33,7 +33,7 @@ func constructJamfProComputerGroup(d *schema.ResourceData) (*jamfpro.ResourceCom
 	}
 
 	// Handle "computers" field
-	if v, ok := d.GetOk("computers"); ok {
+	if v, ok := d.GetOk("computers"); ok && !group.IsSmart {
 		group.Computers = constructGroupComputers(v.([]interface{}))
 	}
 

--- a/internal/endpoints/computergroups/computergroups_resource.go
+++ b/internal/endpoints/computergroups/computergroups_resource.go
@@ -338,20 +338,22 @@ func ResourceJamfProComputerGroupsRead(ctx context.Context, d *schema.ResourceDa
 			diags = append(diags, diag.FromErr(err)...)
 		}
 
-		// Set the computers
-		computersList := make([]interface{}, len(resource.Computers))
-		for i, comp := range resource.Computers {
-			computerMap := map[string]interface{}{
-				"id":              comp.ID,
-				"name":            comp.Name,
-				"mac_address":     comp.MacAddress,
-				"alt_mac_address": comp.AltMacAddress,
-				"serial_number":   comp.SerialNumber,
+		// Set the computers only if the group is not smart
+		if !resource.IsSmart {
+			computersList := make([]interface{}, len(resource.Computers))
+			for i, comp := range resource.Computers {
+				computerMap := map[string]interface{}{
+					"id":              comp.ID,
+					"name":            comp.Name,
+					"mac_address":     comp.MacAddress,
+					"alt_mac_address": comp.AltMacAddress,
+					"serial_number":   comp.SerialNumber,
+				}
+				computersList[i] = computerMap
 			}
-			computersList[i] = computerMap
-		}
-		if err := d.Set("computers", computersList); err != nil {
-			diags = append(diags, diag.FromErr(err)...)
+			if err := d.Set("computers", computersList); err != nil {
+				diags = append(diags, diag.FromErr(err)...)
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR should fix what I was seeing in #145. After building locally, I'm able to successfully import/plan/apply without the `computers` field being added to state or updated when planning.

Oh, and I'm very new to Go so if there is a better way to achieve these checks, please modify away!