### PR TITLE
adds a "more than" smart group criterion search type

### DIFF
--- a/internal/endpoints/computergroups/computergroups_resource.go
+++ b/internal/endpoints/computergroups/computergroups_resource.go
@@ -33,6 +33,7 @@ const (
 	SearchTypeLike                                = "like"
 	SearchTypeNotLike                             = "not like"
 	SearchTypeGreaterThan                         = "greater than"
+	SearchTypeMoreThan                            = "more than"
 	SearchTypeLessThan                            = "less than"
 	SearchTypeGreaterThanOrEqual                  = "greater than or equal"
 	SearchTypeLessThanOrEqual                     = "less than or equal"
@@ -125,15 +126,15 @@ func ResourceJamfProComputerGroups() *schema.Resource {
 						"search_type": {
 							Type:     schema.TypeString,
 							Required: true,
-							Description: fmt.Sprintf("The type of smart group search operator. Allowed values are '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s'. ",
+							Description: fmt.Sprintf("The type of smart group search operator. Allowed values are '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s'. ",
 								SearchTypeIs, SearchTypeIsNot, SearchTypeHas, SearchTypeDoesNotHave, SearchTypeMemberOf, SearchTypeNotMemberOf,
 								SearchTypeBeforeYYYYMMDD, SearchTypeAfterYYYYMMDD, SearchTypeMoreThanXDaysAgo, SearchTypeLessThanXDaysAgo,
-								SearchTypeLike, SearchTypeNotLike, SearchTypeGreaterThan, SearchTypeLessThan, SearchTypeGreaterThanOrEqual,
+								SearchTypeLike, SearchTypeNotLike, SearchTypeGreaterThan, SearchTypeMoreThan, SearchTypeLessThan, SearchTypeGreaterThanOrEqual,
 								SearchTypeLessThanOrEqual, SearchTypeMatchesRegex, SearchTypeDoesNotMatch),
 							ValidateFunc: validation.StringInSlice([]string{
 								SearchTypeIs, SearchTypeIsNot, SearchTypeHas, SearchTypeDoesNotHave, SearchTypeMemberOf, SearchTypeNotMemberOf,
 								SearchTypeBeforeYYYYMMDD, SearchTypeAfterYYYYMMDD, SearchTypeMoreThanXDaysAgo, SearchTypeLessThanXDaysAgo,
-								SearchTypeLike, SearchTypeNotLike, SearchTypeGreaterThan, SearchTypeLessThan, SearchTypeGreaterThanOrEqual,
+								SearchTypeLike, SearchTypeNotLike, SearchTypeGreaterThan, SearchTypeMoreThan, SearchTypeLessThan, SearchTypeGreaterThanOrEqual,
 								SearchTypeLessThanOrEqual, SearchTypeMatchesRegex, SearchTypeDoesNotMatch,
 							}, false),
 						},


### PR DESCRIPTION
As on the tin. A criterion in my Jamf instance accepts this search type:

<img width="1004" alt="Screenshot 2024-04-02 at 7 55 52 PM" src="https://github.com/deploymenttheory/terraform-provider-jamfpro/assets/20032435/a6340708-9c1d-414f-a017-488e9cda91ab">

The referenced extension attribute ("Management - Shard") outputs an integer.

Strangely (due to my ignorance I imagine), when I use "greater than" for the same criterion, the GUI displays search_type "is" - but the API response shows "greater than" nonetheless. If only to avoid Jamf's GUI from lying to me, I'd like to add this search_type.

Hopefully will be able to contribute more substantially in future :)!