### PR TITLE
Adds 'member of' search types to user groups & remove erroneous extension attribute data_type validation

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -4,12 +4,3 @@ default: testacc
 .PHONY: testacc
 testacc:
 	TF_ACC=1 go test ./... -v $(TESTARGS) -timeout 120m
-
-.PHONY: build
-build: ## go build
-	go build .
-
-.PHONY: install
-install: build
-	mkdir -p "/Users/harry.seeber/bin/plugins/registry.terraform.io/hashicorp/jamfpro"
-	mv terraform-provider-jamfpro "/Users/harry.seeber/bin/plugins/registry.terraform.io/hashicorp/jamfpro/terraform-provider-jamfpro"

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -4,3 +4,12 @@ default: testacc
 .PHONY: testacc
 testacc:
 	TF_ACC=1 go test ./... -v $(TESTARGS) -timeout 120m
+
+.PHONY: build
+build: ## go build
+	go build .
+
+.PHONY: install
+install: build
+	mkdir -p "/Users/harry.seeber/bin/plugins/registry.terraform.io/hashicorp/jamfpro"
+	mv terraform-provider-jamfpro "/Users/harry.seeber/bin/plugins/registry.terraform.io/hashicorp/jamfpro/terraform-provider-jamfpro"

--- a/internal/endpoints/computerextensionattributes/computerextensionattributes_data_validation.go
+++ b/internal/endpoints/computerextensionattributes/computerextensionattributes_data_validation.go
@@ -4,24 +4,9 @@ package computerextensionattributes
 import (
 	"context"
 	"fmt"
-	"regexp"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
-
-// validateDataType ensures the provided value adheres to the accepted formats for the data_type attribute.
-// The accepted formats are "String", "Integer", and a date string in the "YYYY-MM-DD hh:mm:ss" format.
-func validateDataType(val interface{}, key string) (warns []string, errs []error) {
-	value := val.(string)
-
-	// Regular expression to validate the date format "YYYY-MM-DD hh:mm:ss"
-	datePattern := `^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$`
-
-	if value != "String" && value != "Integer" && !regexp.MustCompile(datePattern).MatchString(value) {
-		errs = append(errs, fmt.Errorf("%q must be 'String', 'Integer', or 'YYYY-MM-DD hh:mm:ss' format, got: %s", key, value))
-	}
-	return
-}
 
 // validateJamfProRResourceComputerExtensionAttributesDataFields performs custom validation on the Resource's schema so that passed values from
 // teraform resource declarations align with attibute combinations supported by the Jamf Pro api.

--- a/internal/endpoints/computerextensionattributes/computerextensionattributes_resource.go
+++ b/internal/endpoints/computerextensionattributes/computerextensionattributes_resource.go
@@ -61,7 +61,7 @@ func ResourceJamfProComputerExtensionAttributes() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Description:  "Data type of the computer extension attribute. Can be String / Integer / Date (YYYY-MM-DD hh:mm:ss)",
-				ValidateFunc: validateDataType,
+				ValidateFunc: validation.StringInSlice([]string{"String", "Integer", "Date"}, false),
 			},
 			"input_type": {
 				Type:     schema.TypeList,

--- a/internal/endpoints/usergroups/usergroups_resource.go
+++ b/internal/endpoints/usergroups/usergroups_resource.go
@@ -27,6 +27,8 @@ const (
 	SearchTypeNotLike                     = "not like"
 	SearchTypeMatchesRegex                = "matches regex"
 	SearchTypeDoesNotMatch                = "does not match regex"
+	SearchTypeMemberOf                    = "member of"
+	SearchTypeNotMemberOf                 = "not member of"
 )
 
 type UserGroupAndOr string
@@ -119,12 +121,14 @@ func ResourceJamfProUserGroups() *schema.Resource {
 						"search_type": {
 							Type:     schema.TypeString,
 							Optional: true,
-							Description: fmt.Sprintf("The type of user smart group search operator. Allowed values are '%s', '%s', '%s', '%s', '%s', '%s'.",
+							Description: fmt.Sprintf("The type of user smart group search operator. Allowed values are '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s'.",
 								string(SearchTypeIs), string(SearchTypeIsNot), string(SearchTypeLike),
-								string(SearchTypeNotLike), string(SearchTypeMatchesRegex), string(SearchTypeDoesNotMatch)),
+								string(SearchTypeNotLike), string(SearchTypeMatchesRegex), string(SearchTypeDoesNotMatch),
+								string(SearchTypeMemberOf), string(SearchTypeNotMemberOf)),
 							ValidateFunc: validation.StringInSlice([]string{
 								string(SearchTypeIs), string(SearchTypeIsNot), string(SearchTypeLike),
 								string(SearchTypeNotLike), string(SearchTypeMatchesRegex), string(SearchTypeDoesNotMatch),
+								string(SearchTypeMemberOf), string(SearchTypeNotMemberOf),
 							}, false),
 						},
 						"value": {


### PR DESCRIPTION
* "member of" is a valid search type for smart user groups, as with smart computer groups.
![Screenshot 2024-04-05 at 7 39 44 PM](https://github.com/deploymenttheory/terraform-provider-jamfpro/assets/20032435/627b1f3a-5eb7-4645-a160-bfd75e1b7870)

* The data_type field on an extension attribute accepts "String", "Integer", or "Date".  As currently written, the validation for this field requires the value be either "String", "Integer", or an arbitrary date string matching the "Date" data_type's required format. We're not validating the actual ext attr's returned data here, ofc :), so can just delete this and use a standard string slice validation.

Here's an excerpted example API response for an attribute w/ data_type "Date":

```
{
    "id": 59,
    "name": "Last Munki Run",
    "enabled": true,
    "description": "",
    "data_type": "Date",
 ```
 
