### PR TITLE
Added support for sticky sessions when running TF plan and applies

### DIFF
--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -21,7 +21,7 @@ provider "jamfpro" {
   token_refresh_buffer_period = 5 # minutes
   total_retry_duration        = 30 # seconds
   custom_timeout              = 30 # seconds
-  enable_cookie_jar           = false 
+  enable_cookie_jar           = true
   // This setting controls the use of a cookie jar, effectively enabling sticky sessions. When enabled, resources deploy 
   // faster due to a reduced propagation wait time of 10 seconds, however this WILL lead to increased load on a single jamf 
   // pro web application (clustered or otherwise) as it handles all Terraform CRUD operations and negates any load balancing. 

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -21,6 +21,7 @@ provider "jamfpro" {
   token_refresh_buffer_period = 5 # minutes
   total_retry_duration        = 30 # seconds
   custom_timeout              = 30 # seconds
+  enable_cookie_jar           = true  // This setting controls the use of a cookie jar, effectively enabling sticky sessions. When enabled, resources deploy faster due to a reduced propagation wait time of 10 seconds, but this WILL lead to increased load on a single jamf pro web application as it handles all Terraform CRUD operations and negate any load balancing. If disabled, resources adhere to Jamf Cloud's default resource propagation behavior, incorporating a 60+1-second propagation delay.
 }
 variable "jamfpro_instance_name" {
   description = "Jamf Pro Instance name."

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -21,7 +21,13 @@ provider "jamfpro" {
   token_refresh_buffer_period = 5 # minutes
   total_retry_duration        = 30 # seconds
   custom_timeout              = 30 # seconds
-  enable_cookie_jar           = true  // This setting controls the use of a cookie jar, effectively enabling sticky sessions. When enabled, resources deploy faster due to a reduced propagation wait time of 10 seconds, but this WILL lead to increased load on a single jamf pro web application as it handles all Terraform CRUD operations and negate any load balancing. If disabled, resources adhere to Jamf Cloud's default resource propagation behavior, incorporating a 60+1-second propagation delay.
+  enable_cookie_jar           = false 
+  // This setting controls the use of a cookie jar, effectively enabling sticky sessions. When enabled, resources deploy 
+  // faster due to a reduced propagation wait time of 10 seconds, however this WILL lead to increased load on a single jamf 
+  // pro web application (clustered or otherwise) as it handles all Terraform CRUD operations and negates any load balancing. 
+  // Conseqently, deploying resources enmass (e.g creating + 10 resources at a time) can cause unpredictable resource 
+  // deployment / stating errors. If disabled, resources adhere to Jamf Cloud's default resource propagation behavior, 
+  // incorporating a 60+1-second propagation delay.
 }
 variable "jamfpro_instance_name" {
   description = "Jamf Pro Instance name."

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -26,8 +26,9 @@ provider "jamfpro" {
   // faster due to a reduced propagation wait time of 10 seconds, however this WILL lead to increased load on a single jamf 
   // pro web application (clustered or otherwise) as it handles all Terraform CRUD operations and negates any load balancing. 
   // Conseqently, deploying resources enmass (e.g creating + 10 resources at a time) can cause unpredictable resource 
-  // deployment / stating errors. If disabled, resources adhere to Jamf Cloud's default resource propagation behavior, 
-  // incorporating a 60+1-second propagation delay.
+  // deployment / stating errors. especially on more complex resources such as config profiles. If disabled, resources 
+  // adhere to Jamf Cloud's default resource propagation behavior, incorporating a 60+1-second propagation delay before attempting
+  // to state.
 }
 variable "jamfpro_instance_name" {
   description = "Jamf Pro Instance name."

--- a/internal/client/client_config.go
+++ b/internal/client/client_config.go
@@ -15,7 +15,8 @@ type MockAPIClient struct {
 
 // APIClient wraps the Jamf Pro SDK Client.
 type APIClient struct {
-	Conn *jamfpro.Client // Use the SDK client
+	Conn            *jamfpro.Client // Use the SDK client
+	EnableCookieJar bool            // Use the cookie jar value
 }
 
 // This function maps the string log level from the Terraform configuration

--- a/internal/endpoints/accountgroups/accountgroups_resource.go
+++ b/internal/endpoints/accountgroups/accountgroups_resource.go
@@ -30,7 +30,7 @@ func ResourceJamfProAccountGroups() *schema.Resource {
 		DeleteContext: ResourceJamfProAccountGroupDelete,
 		CustomizeDiff: customDiffAccountGroups,
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(120 * time.Second),
+			Create: schema.DefaultTimeout(70 * time.Second),
 			Read:   schema.DefaultTimeout(30 * time.Second),
 			Update: schema.DefaultTimeout(30 * time.Second),
 			Delete: schema.DefaultTimeout(15 * time.Second),

--- a/internal/endpoints/accountgroups/accountgroups_resource.go
+++ b/internal/endpoints/accountgroups/accountgroups_resource.go
@@ -225,7 +225,7 @@ func ResourceJamfProAccountGroupCreate(ctx context.Context, d *schema.ResourceDa
 		return apiclient.Conn.GetAccountGroupByID(intID)
 	}
 
-	_, waitDiags := waitfor.ResourceIsAvailable(ctx, d, "Jamf Pro Account Group", strconv.Itoa(creationResponse.ID), checkResourceExists, time.Duration(common.JamfProPropagationDelay)*time.Second)
+	_, waitDiags := waitfor.ResourceIsAvailable(ctx, d, "Jamf Pro Account Group", strconv.Itoa(creationResponse.ID), checkResourceExists, time.Duration(common.DefaultPropagationTime)*time.Second, apiclient.EnableCookieJar)
 
 	if waitDiags.HasError() {
 		return waitDiags

--- a/internal/endpoints/accounts/accounts_resource.go
+++ b/internal/endpoints/accounts/accounts_resource.go
@@ -298,7 +298,7 @@ func ResourceJamfProAccountCreate(ctx context.Context, d *schema.ResourceData, m
 		return apiclient.Conn.GetAccountByID(intID)
 	}
 
-	_, waitDiags := waitfor.ResourceIsAvailable(ctx, d, "Jamf Pro Account", strconv.Itoa(creationResponse.ID), checkResourceExists, time.Duration(common.JamfProPropagationDelay)*time.Second)
+	_, waitDiags := waitfor.ResourceIsAvailable(ctx, d, "Jamf Pro Account", strconv.Itoa(creationResponse.ID), checkResourceExists, time.Duration(common.DefaultPropagationTime)*time.Second, apiclient.EnableCookieJar)
 	if waitDiags.HasError() {
 		return waitDiags
 	}

--- a/internal/endpoints/accounts/accounts_resource.go
+++ b/internal/endpoints/accounts/accounts_resource.go
@@ -29,7 +29,7 @@ func ResourceJamfProAccounts() *schema.Resource {
 		DeleteContext: ResourceJamfProAccountDelete,
 		CustomizeDiff: customDiffAccounts,
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(120 * time.Second),
+			Create: schema.DefaultTimeout(70 * time.Second),
 			Read:   schema.DefaultTimeout(30 * time.Second),
 			Update: schema.DefaultTimeout(30 * time.Second),
 			Delete: schema.DefaultTimeout(15 * time.Second),

--- a/internal/endpoints/advancedcomputersearches/advancedcomputersearches_resource.go
+++ b/internal/endpoints/advancedcomputersearches/advancedcomputersearches_resource.go
@@ -26,7 +26,7 @@ func ResourceJamfProAdvancedComputerSearches() *schema.Resource {
 		UpdateContext: ResourceJamfProAdvancedComputerSearchUpdate,
 		DeleteContext: ResourceJamfProAdvancedComputerSearchDelete,
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(120 * time.Second),
+			Create: schema.DefaultTimeout(70 * time.Second),
 			Read:   schema.DefaultTimeout(30 * time.Second),
 			Update: schema.DefaultTimeout(30 * time.Second),
 			Delete: schema.DefaultTimeout(15 * time.Second),

--- a/internal/endpoints/advancedcomputersearches/advancedcomputersearches_resource.go
+++ b/internal/endpoints/advancedcomputersearches/advancedcomputersearches_resource.go
@@ -181,7 +181,7 @@ func ResourceJamfProAdvancedComputerSearchCreate(ctx context.Context, d *schema.
 		return apiclient.Conn.GetAdvancedComputerSearchByID(intID)
 	}
 
-	_, waitDiags := waitfor.ResourceIsAvailable(ctx, d, "Jamf Pro Advanced Computer Search", strconv.Itoa(creationResponse.ID), checkResourceExists, time.Duration(common.JamfProPropagationDelay)*time.Second)
+	_, waitDiags := waitfor.ResourceIsAvailable(ctx, d, "Jamf Pro Advanced Computer Search", strconv.Itoa(creationResponse.ID), checkResourceExists, time.Duration(common.DefaultPropagationTime)*time.Second, apiclient.EnableCookieJar)
 	if waitDiags.HasError() {
 		return waitDiags
 	}

--- a/internal/endpoints/advancedmobiledevicesearches/advancedmobiledevicesearches_resource.go
+++ b/internal/endpoints/advancedmobiledevicesearches/advancedmobiledevicesearches_resource.go
@@ -181,7 +181,7 @@ func ResourceJamfProAdvancedMobileDeviceSearchCreate(ctx context.Context, d *sch
 		return apiclient.Conn.GetAdvancedComputerSearchByID(intID)
 	}
 
-	_, waitDiags := waitfor.ResourceIsAvailable(ctx, d, "Jamf Pro Advanced Mobile Device Search", strconv.Itoa(creationResponse.ID), checkResourceExists, time.Duration(common.JamfProPropagationDelay)*time.Second)
+	_, waitDiags := waitfor.ResourceIsAvailable(ctx, d, "Jamf Pro Advanced Mobile Device Search", strconv.Itoa(creationResponse.ID), checkResourceExists, time.Duration(common.DefaultPropagationTime)*time.Second, apiclient.EnableCookieJar)
 	if waitDiags.HasError() {
 		return waitDiags
 	}

--- a/internal/endpoints/advancedmobiledevicesearches/advancedmobiledevicesearches_resource.go
+++ b/internal/endpoints/advancedmobiledevicesearches/advancedmobiledevicesearches_resource.go
@@ -26,7 +26,7 @@ func ResourceJamfProAdvancedMobileDeviceSearches() *schema.Resource {
 		UpdateContext: ResourceJamfProAdvancedMobileDeviceSearchUpdate,
 		DeleteContext: ResourceJamfProAdvancedMobileDeviceSearchDelete,
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(120 * time.Second),
+			Create: schema.DefaultTimeout(70 * time.Second),
 			Read:   schema.DefaultTimeout(30 * time.Second),
 			Update: schema.DefaultTimeout(30 * time.Second),
 			Delete: schema.DefaultTimeout(15 * time.Second),

--- a/internal/endpoints/advancedusersearches/advancedusersearches_resource.go
+++ b/internal/endpoints/advancedusersearches/advancedusersearches_resource.go
@@ -26,7 +26,7 @@ func ResourceJamfProAdvancedUserSearches() *schema.Resource {
 		UpdateContext: ResourceJamfProAdvancedUserSearchUpdate,
 		DeleteContext: ResourceJamfProAdvancedUserSearchDelete,
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(120 * time.Second),
+			Create: schema.DefaultTimeout(70 * time.Second),
 			Read:   schema.DefaultTimeout(30 * time.Second),
 			Update: schema.DefaultTimeout(30 * time.Second),
 			Delete: schema.DefaultTimeout(15 * time.Second),

--- a/internal/endpoints/advancedusersearches/advancedusersearches_resource.go
+++ b/internal/endpoints/advancedusersearches/advancedusersearches_resource.go
@@ -161,7 +161,7 @@ func ResourceJamfProAdvancedUserSearchCreate(ctx context.Context, d *schema.Reso
 		return apiclient.Conn.GetAdvancedUserSearchByID(intID)
 	}
 
-	_, waitDiags := waitfor.ResourceIsAvailable(ctx, d, "Jamf Pro Advanced User Search", strconv.Itoa(creationResponse.ID), checkResourceExists, time.Duration(common.JamfProPropagationDelay)*time.Second)
+	_, waitDiags := waitfor.ResourceIsAvailable(ctx, d, "Jamf Pro Advanced User Search", strconv.Itoa(creationResponse.ID), checkResourceExists, time.Duration(common.DefaultPropagationTime)*time.Second, apiclient.EnableCookieJar)
 	if waitDiags.HasError() {
 		return waitDiags
 	}

--- a/internal/endpoints/allowedfileextensions/allowedfileextensions_resource.go
+++ b/internal/endpoints/allowedfileextensions/allowedfileextensions_resource.go
@@ -95,7 +95,7 @@ func ResourceJamfProAllowedFileExtensionCreate(ctx context.Context, d *schema.Re
 		return apiclient.Conn.GetAccountGroupByID(intID)
 	}
 
-	_, waitDiags := waitfor.ResourceIsAvailable(ctx, d, "Jamf Pro Allowed File Extension", strconv.Itoa(creationResponse.ID), checkResourceExists, time.Duration(common.JamfProPropagationDelay)*time.Second)
+	_, waitDiags := waitfor.ResourceIsAvailable(ctx, d, "Jamf Pro Allowed File Extension", strconv.Itoa(creationResponse.ID), checkResourceExists, time.Duration(common.DefaultPropagationTime)*time.Second, apiclient.EnableCookieJar)
 
 	if waitDiags.HasError() {
 		return waitDiags
@@ -153,24 +153,6 @@ func ResourceJamfProAllowedFileExtensionRead(ctx context.Context, d *schema.Reso
 		}
 		// For other errors, or if this is a create operation, return a diagnostic error
 		return diag.FromErr(err)
-	}
-
-	// If err is not nil, check if it's due to the resource being not found
-	if err != nil {
-		if err.Error() == "resource not found, marked for deletion" {
-			// Resource not found, remove from Terraform state
-			d.SetId("")
-			// Append a warning diagnostic and return
-			diags = append(diags, diag.Diagnostic{
-				Severity: diag.Warning,
-				Summary:  "Resource not found",
-				Detail:   fmt.Sprintf("Jamf Pro Allowed File Extension with ID '%s' was not found on the server and is marked for deletion from terraform state.", resourceID),
-			})
-			return diags
-		}
-
-		// For other errors, return an error diagnostic
-		return diag.FromErr(fmt.Errorf("failed to read Jamf Pro Allowed File Extension with ID '%s' after retries: %v", resourceID, err))
 	}
 
 	// Update the Terraform state with the fetched data

--- a/internal/endpoints/allowedfileextensions/allowedfileextensions_resource.go
+++ b/internal/endpoints/allowedfileextensions/allowedfileextensions_resource.go
@@ -26,7 +26,7 @@ func ResourceJamfProAllowedFileExtensions() *schema.Resource {
 		UpdateContext: ResourceJamfProAllowedFileExtensionUpdate,
 		DeleteContext: ResourceJamfProAllowedFileExtensionDelete,
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(120 * time.Second),
+			Create: schema.DefaultTimeout(70 * time.Second),
 			Read:   schema.DefaultTimeout(30 * time.Second),
 			Update: schema.DefaultTimeout(30 * time.Second),
 			Delete: schema.DefaultTimeout(15 * time.Second),

--- a/internal/endpoints/apiintegrations/apiintegrations_resource.go
+++ b/internal/endpoints/apiintegrations/apiintegrations_resource.go
@@ -27,7 +27,7 @@ func ResourceJamfProApiIntegrations() *schema.Resource {
 		DeleteContext: ResourceJamfProApiIntegrationsDelete,
 		CustomizeDiff: validateResourceAPIIntegrationsDataFields,
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(120 * time.Second),
+			Create: schema.DefaultTimeout(70 * time.Second),
 			Read:   schema.DefaultTimeout(30 * time.Second),
 			Update: schema.DefaultTimeout(30 * time.Second),
 			Delete: schema.DefaultTimeout(15 * time.Second),

--- a/internal/endpoints/apiintegrations/apiintegrations_resource.go
+++ b/internal/endpoints/apiintegrations/apiintegrations_resource.go
@@ -124,7 +124,7 @@ func ResourceJamfProApiIntegrationsCreate(ctx context.Context, d *schema.Resourc
 		return apiclient.Conn.GetAccountGroupByID(intID)
 	}
 
-	_, waitDiags := waitfor.ResourceIsAvailable(ctx, d, "Jamf Pro API Integration", strconv.Itoa(creationResponse.ID), checkResourceExists, time.Duration(common.JamfProPropagationDelay)*time.Second)
+	_, waitDiags := waitfor.ResourceIsAvailable(ctx, d, "Jamf Pro API Integration", strconv.Itoa(creationResponse.ID), checkResourceExists, time.Duration(common.DefaultPropagationTime)*time.Second, apiclient.EnableCookieJar)
 
 	if waitDiags.HasError() {
 		return waitDiags

--- a/internal/endpoints/apiintegrations/apiintegrations_resource.go
+++ b/internal/endpoints/apiintegrations/apiintegrations_resource.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
 	"github.com/deploymenttheory/terraform-provider-jamfpro/internal/client"
+	"github.com/deploymenttheory/terraform-provider-jamfpro/internal/endpoints/common"
+	"github.com/deploymenttheory/terraform-provider-jamfpro/internal/waitfor"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
@@ -91,7 +93,7 @@ func ResourceJamfProApiIntegrationsCreate(ctx context.Context, d *schema.Resourc
 	// Construct the resource object
 	resource, err := constructJamfProApiIntegration(d)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("failed to construct Jamf Pro Site: %v", err))
+		return diag.FromErr(fmt.Errorf("failed to construct Jamf Pro Account Group: %v", err))
 	}
 
 	// Retry the API call to create the resource in Jamf Pro
@@ -112,6 +114,21 @@ func ResourceJamfProApiIntegrationsCreate(ctx context.Context, d *schema.Resourc
 
 	// Set the resource ID in Terraform state
 	d.SetId(strconv.Itoa(creationResponse.ID))
+
+	// Wait for the resource to be fully available before reading it
+	checkResourceExists := func(id interface{}) (interface{}, error) {
+		intID, err := strconv.Atoi(id.(string))
+		if err != nil {
+			return nil, fmt.Errorf("error converting ID '%v' to integer: %v", id, err)
+		}
+		return apiclient.Conn.GetAccountGroupByID(intID)
+	}
+
+	_, waitDiags := waitfor.ResourceIsAvailable(ctx, d, "Jamf Pro API Integration", strconv.Itoa(creationResponse.ID), checkResourceExists, time.Duration(common.JamfProPropagationDelay)*time.Second)
+
+	if waitDiags.HasError() {
+		return waitDiags
+	}
 
 	// Read the resource to ensure the Terraform state is up to date
 	readDiags := ResourceJamfProApiIntegrationsRead(ctx, d, meta)
@@ -141,39 +158,26 @@ func ResourceJamfProApiIntegrationsRead(ctx context.Context, d *schema.ResourceD
 		return diag.FromErr(fmt.Errorf("error converting resource ID '%s' to int: %v", resourceID, err))
 	}
 
-	var resource *jamfpro.ResourceApiIntegration
+	// Attempt to fetch the resource by ID
+	resource, err := conn.GetApiIntegrationByID(resourceIDInt)
 
-	// Read operation with retry
-	err = retry.RetryContext(ctx, d.Timeout(schema.TimeoutRead), func() *retry.RetryError {
-		var apiErr error
-		resource, apiErr = conn.GetApiIntegrationByID(resourceIDInt)
-		if apiErr != nil {
-			if strings.Contains(apiErr.Error(), "404") || strings.Contains(apiErr.Error(), "410") {
-				// Return non-retryable error with a message to avoid SDK issues
-				return retry.NonRetryableError(fmt.Errorf("resource not found, marked for deletion"))
-			}
-			// Retry for other types of errors
-			return retry.RetryableError(apiErr)
-		}
-		return nil
-	})
-
-	// If err is not nil, check if it's due to the resource being not found
 	if err != nil {
-		if err.Error() == "resource not found, marked for deletion" {
-			// Resource not found, remove from Terraform state
-			d.SetId("")
-			// Append a warning diagnostic and return
-			diags = append(diags, diag.Diagnostic{
-				Severity: diag.Warning,
-				Summary:  "Resource not found",
-				Detail:   fmt.Sprintf("Jamf Pro API Integration with ID '%s' was not found on the server and is marked for deletion from terraform state.", resourceID),
-			})
-			return diags
+		// Skip resource state removal if this is a create operation
+		if !d.IsNewResource() {
+			// If the error is a "not found" error, remove the resource from the state
+			if strings.Contains(err.Error(), "404") || strings.Contains(err.Error(), "410") {
+				d.SetId("") // Remove the resource from Terraform state
+				return diag.Diagnostics{
+					{
+						Severity: diag.Warning,
+						Summary:  "Resource not found",
+						Detail:   fmt.Sprintf("Jamf Pro API Integration resource with ID '%s' was not found and has been removed from the Terraform state.", resourceID),
+					},
+				}
+			}
 		}
-
-		// For other errors, return an error diagnostic
-		return diag.FromErr(fmt.Errorf("failed to read Jamf Pro API Integration with ID '%s' after retries: %v", resourceID, err))
+		// For other errors, or if this is a create operation, return a diagnostic error
+		return diag.FromErr(err)
 	}
 
 	// Map the configuration fields from the API response to a structured map

--- a/internal/endpoints/apiroles/apiroles_resource.go
+++ b/internal/endpoints/apiroles/apiroles_resource.go
@@ -26,7 +26,7 @@ func ResourceJamfProAPIRoles() *schema.Resource {
 		UpdateContext: ResourceJamfProAPIRolesUpdate,
 		DeleteContext: ResourceJamfProAPIRolesDelete,
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(120 * time.Second),
+			Create: schema.DefaultTimeout(70 * time.Second),
 			Read:   schema.DefaultTimeout(30 * time.Second),
 			Update: schema.DefaultTimeout(30 * time.Second),
 			Delete: schema.DefaultTimeout(15 * time.Second),

--- a/internal/endpoints/apiroles/apiroles_resource.go
+++ b/internal/endpoints/apiroles/apiroles_resource.go
@@ -108,7 +108,7 @@ func ResourceJamfProAPIRolesCreate(ctx context.Context, d *schema.ResourceData, 
 		return apiclient.Conn.GetAccountGroupByID(intID)
 	}
 
-	_, waitDiags := waitfor.ResourceIsAvailable(ctx, d, "Jamf Pro API Role", creationResponse.ID, checkResourceExists, time.Duration(common.JamfProPropagationDelay)*time.Second)
+	_, waitDiags := waitfor.ResourceIsAvailable(ctx, d, "Jamf Pro API Role", creationResponse.ID, checkResourceExists, time.Duration(common.DefaultPropagationTime)*time.Second, apiclient.EnableCookieJar)
 
 	if waitDiags.HasError() {
 		return waitDiags

--- a/internal/endpoints/apiroles/apiroles_resource.go
+++ b/internal/endpoints/apiroles/apiroles_resource.go
@@ -4,11 +4,14 @@ package apiroles
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
 	"github.com/deploymenttheory/terraform-provider-jamfpro/internal/client"
+	"github.com/deploymenttheory/terraform-provider-jamfpro/internal/endpoints/common"
+	"github.com/deploymenttheory/terraform-provider-jamfpro/internal/waitfor"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
@@ -74,7 +77,7 @@ func ResourceJamfProAPIRolesCreate(ctx context.Context, d *schema.ResourceData, 
 	// Construct the resource object
 	resource, err := constructJamfProApiRole(d)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("failed to construct Jamf Pro Site: %v", err))
+		return diag.FromErr(fmt.Errorf("failed to construct Jamf Pro Account Group: %v", err))
 	}
 
 	// Retry the API call to create the resource in Jamf Pro
@@ -95,6 +98,21 @@ func ResourceJamfProAPIRolesCreate(ctx context.Context, d *schema.ResourceData, 
 
 	// Set the resource ID in Terraform state
 	d.SetId(creationResponse.ID)
+
+	// Wait for the resource to be fully available before reading it
+	checkResourceExists := func(id interface{}) (interface{}, error) {
+		intID, err := strconv.Atoi(id.(string))
+		if err != nil {
+			return nil, fmt.Errorf("error converting ID '%v' to integer: %v", id, err)
+		}
+		return apiclient.Conn.GetAccountGroupByID(intID)
+	}
+
+	_, waitDiags := waitfor.ResourceIsAvailable(ctx, d, "Jamf Pro API Role", creationResponse.ID, checkResourceExists, time.Duration(common.JamfProPropagationDelay)*time.Second)
+
+	if waitDiags.HasError() {
+		return waitDiags
+	}
 
 	// Read the resource to ensure the Terraform state is up to date
 	readDiags := ResourceJamfProAPIRolesRead(ctx, d, meta)
@@ -122,39 +140,26 @@ func ResourceJamfProAPIRolesRead(ctx context.Context, d *schema.ResourceData, me
 	var diags diag.Diagnostics
 	resourceID := d.Id()
 
-	var resource *jamfpro.ResourceAPIRole
+	// Attempt to fetch the resource by ID
+	resource, err := conn.GetJamfApiRoleByID(resourceID)
 
-	// Read operation with retry
-	err := retry.RetryContext(ctx, d.Timeout(schema.TimeoutRead), func() *retry.RetryError {
-		var apiErr error
-		resource, apiErr = conn.GetJamfApiRoleByID(resourceID)
-		if apiErr != nil {
-			if strings.Contains(apiErr.Error(), "404") || strings.Contains(apiErr.Error(), "410") {
-				// Return non-retryable error with a message to avoid SDK issues
-				return retry.NonRetryableError(fmt.Errorf("resource not found, marked for deletion"))
-			}
-			// Retry for other types of errors
-			return retry.RetryableError(apiErr)
-		}
-		return nil
-	})
-
-	// If err is not nil, check if it's due to the resource being not found
 	if err != nil {
-		if err.Error() == "resource not found, marked for deletion" {
-			// Resource not found, remove from Terraform state
-			d.SetId("")
-			// Append a warning diagnostic and return
-			diags = append(diags, diag.Diagnostic{
-				Severity: diag.Warning,
-				Summary:  "Resource not found",
-				Detail:   fmt.Sprintf("Jamf Pro Api Role with ID '%s' was not found on the server and is marked for deletion from terraform state.", resourceID),
-			})
-			return diags
+		// Skip resource state removal if this is a create operation
+		if !d.IsNewResource() {
+			// If the error is a "not found" error, remove the resource from the state
+			if strings.Contains(err.Error(), "404") || strings.Contains(err.Error(), "410") {
+				d.SetId("") // Remove the resource from Terraform state
+				return diag.Diagnostics{
+					{
+						Severity: diag.Warning,
+						Summary:  "Resource not found",
+						Detail:   fmt.Sprintf("Jamf Pro API Role resource with ID '%s' was not found and has been removed from the Terraform state.", resourceID),
+					},
+				}
+			}
 		}
-
-		// For other errors, return an error diagnostic
-		return diag.FromErr(fmt.Errorf("failed to read Jamf Pro Api Role with ID '%s' after retries: %v", resourceID, err))
+		// For other errors, or if this is a create operation, return a diagnostic error
+		return diag.FromErr(err)
 	}
 
 	// Map the configuration fields from the API response to a structured map

--- a/internal/endpoints/buildings/buildings_resource.go
+++ b/internal/endpoints/buildings/buildings_resource.go
@@ -4,11 +4,14 @@ package buildings
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
 	"github.com/deploymenttheory/terraform-provider-jamfpro/internal/client"
+	"github.com/deploymenttheory/terraform-provider-jamfpro/internal/endpoints/common"
+	"github.com/deploymenttheory/terraform-provider-jamfpro/internal/waitfor"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
@@ -93,7 +96,7 @@ func ResourceJamfProBuildingCreate(ctx context.Context, d *schema.ResourceData, 
 	// Construct the resource object
 	resource, err := constructJamfProBuilding(d)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("failed to construct Jamf Pro Buildings: %v", err))
+		return diag.FromErr(fmt.Errorf("failed to construct Jamf Pro Building: %v", err))
 	}
 
 	// Retry the API call to create the resource in Jamf Pro
@@ -114,6 +117,21 @@ func ResourceJamfProBuildingCreate(ctx context.Context, d *schema.ResourceData, 
 
 	// Set the resource ID in Terraform state
 	d.SetId(creationResponse.ID)
+
+	// Wait for the resource to be fully available before reading it
+	checkResourceExists := func(id interface{}) (interface{}, error) {
+		intID, err := strconv.Atoi(id.(string))
+		if err != nil {
+			return nil, fmt.Errorf("error converting ID '%v' to integer: %v", id, err)
+		}
+		return apiclient.Conn.GetAccountGroupByID(intID)
+	}
+
+	_, waitDiags := waitfor.ResourceIsAvailable(ctx, d, "Jamf Pro Building", creationResponse.ID, checkResourceExists, time.Duration(common.JamfProPropagationDelay)*time.Second)
+
+	if waitDiags.HasError() {
+		return waitDiags
+	}
 
 	// Read the resource to ensure the Terraform state is up to date
 	readDiags := ResourceJamfProBuildingRead(ctx, d, meta)
@@ -141,39 +159,26 @@ func ResourceJamfProBuildingRead(ctx context.Context, d *schema.ResourceData, me
 	var diags diag.Diagnostics
 	resourceID := d.Id()
 
-	var resource *jamfpro.ResourceBuilding
+	// Attempt to fetch the resource by ID
+	resource, err := conn.GetBuildingByID(resourceID)
 
-	// Read operation with retry
-	err := retry.RetryContext(ctx, d.Timeout(schema.TimeoutRead), func() *retry.RetryError {
-		var apiErr error
-		resource, apiErr = conn.GetBuildingByID(resourceID)
-		if apiErr != nil {
-			if strings.Contains(apiErr.Error(), "404") || strings.Contains(apiErr.Error(), "410") {
-				// Return non-retryable error with a message to avoid SDK issues
-				return retry.NonRetryableError(fmt.Errorf("resource not found, marked for deletion"))
-			}
-			// Retry for other types of errors
-			return retry.RetryableError(apiErr)
-		}
-		return nil
-	})
-
-	// If err is not nil, check if it's due to the resource being not found
 	if err != nil {
-		if err.Error() == "resource not found, marked for deletion" {
-			// Resource not found, remove from Terraform state
-			d.SetId("")
-			// Append a warning diagnostic and return
-			diags = append(diags, diag.Diagnostic{
-				Severity: diag.Warning,
-				Summary:  "Resource not found",
-				Detail:   fmt.Sprintf("Jamf Pro Buildings with ID '%s' was not found on the server and is marked for deletion from terraform state.", resourceID),
-			})
-			return diags
+		// Skip resource state removal if this is a create operation
+		if !d.IsNewResource() {
+			// If the error is a "not found" error, remove the resource from the state
+			if strings.Contains(err.Error(), "404") || strings.Contains(err.Error(), "410") {
+				d.SetId("") // Remove the resource from Terraform state
+				return diag.Diagnostics{
+					{
+						Severity: diag.Warning,
+						Summary:  "Resource not found",
+						Detail:   fmt.Sprintf("Jamf Pro Building resource with ID '%s' was not found and has been removed from the Terraform state.", resourceID),
+					},
+				}
+			}
 		}
-
-		// For other errors, return an error diagnostic
-		return diag.FromErr(fmt.Errorf("failed to read Jamf Pro Buildings with ID '%s' after retries: %v", resourceID, err))
+		// For other errors, or if this is a create operation, return a diagnostic error
+		return diag.FromErr(err)
 	}
 
 	// Map the configuration fields from the API response to a structured map

--- a/internal/endpoints/buildings/buildings_resource.go
+++ b/internal/endpoints/buildings/buildings_resource.go
@@ -26,7 +26,7 @@ func ResourceJamfProBuildings() *schema.Resource {
 		UpdateContext: ResourceJamfProBuildingUpdate,
 		DeleteContext: ResourceJamfProBuildingDelete,
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(120 * time.Second),
+			Create: schema.DefaultTimeout(70 * time.Second),
 			Read:   schema.DefaultTimeout(30 * time.Second),
 			Update: schema.DefaultTimeout(30 * time.Second),
 			Delete: schema.DefaultTimeout(15 * time.Second),

--- a/internal/endpoints/buildings/buildings_resource.go
+++ b/internal/endpoints/buildings/buildings_resource.go
@@ -127,7 +127,7 @@ func ResourceJamfProBuildingCreate(ctx context.Context, d *schema.ResourceData, 
 		return apiclient.Conn.GetAccountGroupByID(intID)
 	}
 
-	_, waitDiags := waitfor.ResourceIsAvailable(ctx, d, "Jamf Pro Building", creationResponse.ID, checkResourceExists, time.Duration(common.JamfProPropagationDelay)*time.Second)
+	_, waitDiags := waitfor.ResourceIsAvailable(ctx, d, "Jamf Pro Building", creationResponse.ID, checkResourceExists, time.Duration(common.DefaultPropagationTime)*time.Second, apiclient.EnableCookieJar)
 
 	if waitDiags.HasError() {
 		return waitDiags

--- a/internal/endpoints/categories/categories_resource.go
+++ b/internal/endpoints/categories/categories_resource.go
@@ -27,7 +27,7 @@ func ResourceJamfProCategories() *schema.Resource {
 		UpdateContext: ResourceJamfProCategoriesUpdate,
 		DeleteContext: ResourceJamfProCategoriesDelete,
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(120 * time.Second),
+			Create: schema.DefaultTimeout(70 * time.Second),
 			Read:   schema.DefaultTimeout(30 * time.Second),
 			Update: schema.DefaultTimeout(30 * time.Second),
 			Delete: schema.DefaultTimeout(15 * time.Second),

--- a/internal/endpoints/categories/categories_resource.go
+++ b/internal/endpoints/categories/categories_resource.go
@@ -108,7 +108,7 @@ func ResourceJamfProCategoriesCreate(ctx context.Context, d *schema.ResourceData
 		return apiclient.Conn.GetAccountGroupByID(intID)
 	}
 
-	_, waitDiags := waitfor.ResourceIsAvailable(ctx, d, "Jamf Pro Category", creationResponse.ID, checkResourceExists, time.Duration(common.JamfProPropagationDelay)*time.Second)
+	_, waitDiags := waitfor.ResourceIsAvailable(ctx, d, "Jamf Pro Category", creationResponse.ID, checkResourceExists, time.Duration(common.DefaultPropagationTime)*time.Second, apiclient.EnableCookieJar)
 
 	if waitDiags.HasError() {
 		return waitDiags

--- a/internal/endpoints/common/constants.go
+++ b/internal/endpoints/common/constants.go
@@ -2,5 +2,5 @@
 package common
 
 const (
-	JamfProPropagationDelay = 60 // used for jamfcloud resource propagation across jamf pro load balanced web apps
+	DefaultPropagationTime = 61 // used for jamfcloud resource propagation across jamf pro load balanced web apps
 )

--- a/internal/endpoints/computercheckin/computercheckin_resource.go
+++ b/internal/endpoints/computercheckin/computercheckin_resource.go
@@ -26,7 +26,7 @@ func ResourceJamfProComputerCheckin() *schema.Resource {
 			return validateComputerCheckinDependencies(d)
 		},
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(120 * time.Second),
+			Create: schema.DefaultTimeout(70 * time.Second),
 			Read:   schema.DefaultTimeout(30 * time.Second),
 			Update: schema.DefaultTimeout(30 * time.Second),
 			Delete: schema.DefaultTimeout(15 * time.Second),

--- a/internal/endpoints/computerextensionattributes/computerextensionattributes_resource.go
+++ b/internal/endpoints/computerextensionattributes/computerextensionattributes_resource.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
 	"github.com/deploymenttheory/terraform-provider-jamfpro/internal/client"
+	"github.com/deploymenttheory/terraform-provider-jamfpro/internal/endpoints/common"
 	"github.com/deploymenttheory/terraform-provider-jamfpro/internal/waitfor"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -164,7 +165,7 @@ func ResourceJamfProComputerExtensionAttributesCreate(ctx context.Context, d *sc
 		return apiclient.Conn.GetComputerExtensionAttributeByID(intID)
 	}
 
-	_, waitDiags := waitfor.ResourceIsAvailable(ctx, d, "Jamf Pro Computer Extension Attribute", strconv.Itoa(creationResponse.ID), checkResourceExists, 45*time.Second)
+	_, waitDiags := waitfor.ResourceIsAvailable(ctx, d, "Jamf Pro Computer Extension Attribute", strconv.Itoa(creationResponse.ID), checkResourceExists, time.Duration(common.DefaultPropagationTime)*time.Second, apiclient.EnableCookieJar)
 	if waitDiags.HasError() {
 		return waitDiags
 	}

--- a/internal/endpoints/computerextensionattributes/computerextensionattributes_resource.go
+++ b/internal/endpoints/computerextensionattributes/computerextensionattributes_resource.go
@@ -29,7 +29,7 @@ func ResourceJamfProComputerExtensionAttributes() *schema.Resource {
 		DeleteContext: ResourceJamfProComputerExtensionAttributesDelete,
 		CustomizeDiff: validateJamfProRResourceComputerExtensionAttributesDataFields,
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(120 * time.Second),
+			Create: schema.DefaultTimeout(70 * time.Second),
 			Read:   schema.DefaultTimeout(30 * time.Second),
 			Update: schema.DefaultTimeout(30 * time.Second),
 			Delete: schema.DefaultTimeout(15 * time.Second),

--- a/internal/endpoints/computergroups/computergroups_resource.go
+++ b/internal/endpoints/computergroups/computergroups_resource.go
@@ -249,7 +249,7 @@ func ResourceJamfProComputerGroupsCreate(ctx context.Context, d *schema.Resource
 		return apiclient.Conn.GetAccountGroupByID(intID)
 	}
 
-	_, waitDiags := waitfor.ResourceIsAvailable(ctx, d, "Jamf Pro Computer Group", strconv.Itoa(creationResponse.ID), checkResourceExists, time.Duration(common.JamfProPropagationDelay)*time.Second)
+	_, waitDiags := waitfor.ResourceIsAvailable(ctx, d, "Jamf Pro Computer Group", strconv.Itoa(creationResponse.ID), checkResourceExists, time.Duration(common.DefaultPropagationTime)*time.Second, apiclient.EnableCookieJar)
 
 	if waitDiags.HasError() {
 		return waitDiags

--- a/internal/endpoints/computergroups/computergroups_resource.go
+++ b/internal/endpoints/computergroups/computergroups_resource.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
 	"github.com/deploymenttheory/terraform-provider-jamfpro/internal/client"
+	"github.com/deploymenttheory/terraform-provider-jamfpro/internal/endpoints/common"
+	"github.com/deploymenttheory/terraform-provider-jamfpro/internal/waitfor"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
@@ -238,7 +240,22 @@ func ResourceJamfProComputerGroupsCreate(ctx context.Context, d *schema.Resource
 	// Set the resource ID in Terraform state
 	d.SetId(strconv.Itoa(creationResponse.ID))
 
-	// Read the site to ensure the Terraform state is up to date
+	// Wait for the resource to be fully available before reading it
+	checkResourceExists := func(id interface{}) (interface{}, error) {
+		intID, err := strconv.Atoi(id.(string))
+		if err != nil {
+			return nil, fmt.Errorf("error converting ID '%v' to integer: %v", id, err)
+		}
+		return apiclient.Conn.GetAccountGroupByID(intID)
+	}
+
+	_, waitDiags := waitfor.ResourceIsAvailable(ctx, d, "Jamf Pro Computer Group", strconv.Itoa(creationResponse.ID), checkResourceExists, time.Duration(common.JamfProPropagationDelay)*time.Second)
+
+	if waitDiags.HasError() {
+		return waitDiags
+	}
+
+	// Read the resource to ensure the Terraform state is up to date
 	readDiags := ResourceJamfProComputerGroupsRead(ctx, d, meta)
 	if len(readDiags) > 0 {
 		diags = append(diags, readDiags...)
@@ -266,39 +283,26 @@ func ResourceJamfProComputerGroupsRead(ctx context.Context, d *schema.ResourceDa
 		return diag.FromErr(fmt.Errorf("error converting resource ID '%s' to int: %v", resourceID, err))
 	}
 
-	var resource *jamfpro.ResourceComputerGroup
+	// Attempt to fetch the resource by ID
+	resource, err := conn.GetComputerGroupByID(resourceIDInt)
 
-	// Read operation with retry
-	err = retry.RetryContext(ctx, d.Timeout(schema.TimeoutRead), func() *retry.RetryError {
-		var apiErr error
-		resource, apiErr = conn.GetComputerGroupByID(resourceIDInt)
-		if apiErr != nil {
-			if strings.Contains(apiErr.Error(), "404") || strings.Contains(apiErr.Error(), "410") {
-				// Return non-retryable error with a message to avoid SDK issues
-				return retry.NonRetryableError(fmt.Errorf("resource not found, marked for deletion"))
-			}
-			// Retry for other types of errors
-			return retry.RetryableError(apiErr)
-		}
-		return nil
-	})
-
-	// If err is not nil, check if it's due to the resource being not found
 	if err != nil {
-		if err.Error() == "resource not found, marked for deletion" {
-			// Resource not found, remove from Terraform state
-			d.SetId("")
-			// Append a warning diagnostic and return
-			diags = append(diags, diag.Diagnostic{
-				Severity: diag.Warning,
-				Summary:  "Resource not found",
-				Detail:   fmt.Sprintf("Jamf Pro Computer Group with ID '%s' was not found on the server and is marked for deletion from terraform state.", resourceID),
-			})
-			return diags
+		// Skip resource state removal if this is a create operation
+		if !d.IsNewResource() {
+			// If the error is a "not found" error, remove the resource from the state
+			if strings.Contains(err.Error(), "404") || strings.Contains(err.Error(), "410") {
+				d.SetId("") // Remove the resource from Terraform state
+				return diag.Diagnostics{
+					{
+						Severity: diag.Warning,
+						Summary:  "Resource not found",
+						Detail:   fmt.Sprintf("Jamf Pro Computer Group resource with ID '%s' was not found and has been removed from the Terraform state.", resourceID),
+					},
+				}
+			}
 		}
-
-		// For other errors, return an error diagnostic
-		return diag.FromErr(fmt.Errorf("failed to read Jamf Pro Computer Group with ID '%s' after retries: %v", resourceID, err))
+		// For other errors, or if this is a create operation, return a diagnostic error
+		return diag.FromErr(err)
 	}
 
 	// Update the Terraform state with the fetched data

--- a/internal/endpoints/computergroups/computergroups_resource.go
+++ b/internal/endpoints/computergroups/computergroups_resource.go
@@ -53,7 +53,7 @@ func ResourceJamfProComputerGroups() *schema.Resource {
 		UpdateContext: ResourceJamfProComputerGroupsUpdate,
 		DeleteContext: ResourceJamfProComputerGroupsDelete,
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(120 * time.Second),
+			Create: schema.DefaultTimeout(70 * time.Second),
 			Read:   schema.DefaultTimeout(30 * time.Second),
 			Update: schema.DefaultTimeout(30 * time.Second),
 			Delete: schema.DefaultTimeout(15 * time.Second),

--- a/internal/endpoints/computerprestageenrollments/computerprestageenrollments_resource.go
+++ b/internal/endpoints/computerprestageenrollments/computerprestageenrollments_resource.go
@@ -600,7 +600,7 @@ func ResourceJamfProComputerPrestageEnrollmentCreate(ctx context.Context, d *sch
 		return apiclient.Conn.GetComputerPrestageByID(id.(string))
 	}
 
-	_, waitDiags := waitfor.ResourceIsAvailable(ctx, d, "Jamf Pro Computer Prestage Enrollment", creationResponse.ID, checkResourceExists, time.Duration(common.JamfProPropagationDelay)*time.Second)
+	_, waitDiags := waitfor.ResourceIsAvailable(ctx, d, "Jamf Pro Computer Prestage Enrollment", creationResponse.ID, checkResourceExists, time.Duration(common.DefaultPropagationTime)*time.Second, apiclient.EnableCookieJar)
 	if waitDiags.HasError() {
 		return waitDiags
 	}

--- a/internal/endpoints/computerprestageenrollments/computerprestageenrollments_resource.go
+++ b/internal/endpoints/computerprestageenrollments/computerprestageenrollments_resource.go
@@ -26,7 +26,7 @@ func ResourceJamfProComputerPrestageEnrollmentEnrollment() *schema.Resource {
 		UpdateContext: ResourceJamfProComputerPrestageEnrollmentUpdate,
 		DeleteContext: ResourceJamfProComputerPrestageEnrollmentDelete,
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(120 * time.Second),
+			Create: schema.DefaultTimeout(70 * time.Second),
 			Read:   schema.DefaultTimeout(30 * time.Second),
 			Update: schema.DefaultTimeout(30 * time.Second),
 			Delete: schema.DefaultTimeout(15 * time.Second),

--- a/internal/endpoints/computerprestageenrollments/computerprestageenrollments_resource.go
+++ b/internal/endpoints/computerprestageenrollments/computerprestageenrollments_resource.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
 	"github.com/deploymenttheory/terraform-provider-jamfpro/internal/client"
+	"github.com/deploymenttheory/terraform-provider-jamfpro/internal/endpoints/common"
 	"github.com/deploymenttheory/terraform-provider-jamfpro/internal/waitfor"
 
 	util "github.com/deploymenttheory/terraform-provider-jamfpro/internal/helpers/type_assertion"
@@ -572,7 +573,7 @@ func ResourceJamfProComputerPrestageEnrollmentCreate(ctx context.Context, d *sch
 	// Construct the resource object
 	resource, err := constructJamfProComputerPrestageEnrollment(d)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("failed to construct Jamf Pro computer prestage enrollment: %v", err))
+		return diag.FromErr(fmt.Errorf("failed to construct Jamf Pro Computer Prestage Enrollment: %v", err))
 	}
 
 	// Retry the API call to create the resource in Jamf Pro
@@ -588,7 +589,7 @@ func ResourceJamfProComputerPrestageEnrollmentCreate(ctx context.Context, d *sch
 	})
 
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("failed to create Jamf Pro computer prestage enrollment '%s' after retries: %v", resource.DisplayName, err))
+		return diag.FromErr(fmt.Errorf("failed to create Jamf Pro Computer Prestage Enrollment '%s' after retries: %v", resource.DisplayName, err))
 	}
 
 	// Set the resource ID in Terraform state
@@ -599,7 +600,7 @@ func ResourceJamfProComputerPrestageEnrollmentCreate(ctx context.Context, d *sch
 		return apiclient.Conn.GetComputerPrestageByID(id.(string))
 	}
 
-	_, waitDiags := waitfor.ResourceIsAvailable(ctx, d, "Jamf Pro computer prestage enrollment", creationResponse.ID, checkResourceExists, 10*time.Second)
+	_, waitDiags := waitfor.ResourceIsAvailable(ctx, d, "Jamf Pro Computer Prestage Enrollment", creationResponse.ID, checkResourceExists, time.Duration(common.JamfProPropagationDelay)*time.Second)
 	if waitDiags.HasError() {
 		return waitDiags
 	}
@@ -641,7 +642,7 @@ func ResourceJamfProComputerPrestageEnrollmentRead(ctx context.Context, d *schem
 					{
 						Severity: diag.Warning,
 						Summary:  "Resource not found",
-						Detail:   fmt.Sprintf("Jamf Pro computer prestage enrollment resource with ID '%s' was not found and has been removed from the Terraform state.", resourceID),
+						Detail:   fmt.Sprintf("Jamf Pro Computer Prestage Enrollment resource with ID '%s' was not found and has been removed from the Terraform state.", resourceID),
 					},
 				}
 			}

--- a/internal/endpoints/departments/departments_resource.go
+++ b/internal/endpoints/departments/departments_resource.go
@@ -4,11 +4,14 @@ package departments
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
 	"github.com/deploymenttheory/terraform-provider-jamfpro/internal/client"
+	"github.com/deploymenttheory/terraform-provider-jamfpro/internal/endpoints/common"
+	"github.com/deploymenttheory/terraform-provider-jamfpro/internal/waitfor"
 
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -64,24 +67,48 @@ func ResourceJamfProDepartmentsCreate(ctx context.Context, d *schema.ResourceDat
 
 	// Initialize variables
 	var diags diag.Diagnostics
-	resourceName := d.Get("name").(string)
 
-	// Construct the department object
-	department, err := constructJamfProDepartment(d)
+	// Construct the resource object
+	resource, err := constructJamfProDepartment(d)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("failed to construct Jamf Pro Department '%s': %v", resourceName, err))
+		return diag.FromErr(fmt.Errorf("failed to construct Jamf Pro Department: %v", err))
 	}
 
-	// Attempt to create the department in Jamf Pro
-	creationResponse, err := conn.CreateDepartment(department)
+	// Retry the API call to create the resource in Jamf Pro
+	var creationResponse *jamfpro.ResponseDepartmentCreate
+	err = retry.RetryContext(ctx, d.Timeout(schema.TimeoutCreate), func() *retry.RetryError {
+		var apiErr error
+		creationResponse, apiErr = conn.CreateDepartment(resource)
+		if apiErr != nil {
+			return retry.RetryableError(apiErr)
+		}
+		// No error, exit the retry loop
+		return nil
+	})
+
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("failed to create Jamf Pro Department '%s': %v", resourceName, err))
+		return diag.FromErr(fmt.Errorf("failed to create Jamf Pro Department '%s' after retries: %v", resource.Name, err))
 	}
 
-	// Set the resource ID in the Terraform state
+	// Set the resource ID in Terraform state
 	d.SetId(creationResponse.ID)
 
-	// Sync the Terraform state with the remote system
+	// Wait for the resource to be fully available before reading it
+	checkResourceExists := func(id interface{}) (interface{}, error) {
+		intID, err := strconv.Atoi(id.(string))
+		if err != nil {
+			return nil, fmt.Errorf("error converting ID '%v' to integer: %v", id, err)
+		}
+		return apiclient.Conn.GetAccountGroupByID(intID)
+	}
+
+	_, waitDiags := waitfor.ResourceIsAvailable(ctx, d, "Jamf Pro Department", creationResponse.ID, checkResourceExists, time.Duration(common.JamfProPropagationDelay)*time.Second)
+
+	if waitDiags.HasError() {
+		return waitDiags
+	}
+
+	// Read the resource to ensure the Terraform state is up to date
 	readDiags := ResourceJamfProDepartmentsRead(ctx, d, meta)
 	if len(readDiags) > 0 {
 		diags = append(diags, readDiags...)
@@ -107,39 +134,27 @@ func ResourceJamfProDepartmentsRead(ctx context.Context, d *schema.ResourceData,
 	// Initialize variables
 	var diags diag.Diagnostics
 	resourceID := d.Id()
-	var resource *jamfpro.ResourceDepartment
 
-	// Read operation with retry
-	err := retry.RetryContext(ctx, d.Timeout(schema.TimeoutRead), func() *retry.RetryError {
-		var apiErr error
-		resource, apiErr = conn.GetDepartmentByID(resourceID)
-		if apiErr != nil {
-			if strings.Contains(apiErr.Error(), "404") || strings.Contains(apiErr.Error(), "410") {
-				// Return non-retryable error with a message to avoid SDK issues
-				return retry.NonRetryableError(fmt.Errorf("resource not found, marked for deletion"))
-			}
-			// Retry for other types of errors
-			return retry.RetryableError(apiErr)
-		}
-		return nil
-	})
+	// Attempt to fetch the resource by ID
+	resource, err := conn.GetDepartmentByID(resourceID)
 
-	// If err is not nil, check if it's due to the resource being not found
 	if err != nil {
-		if err.Error() == "resource not found, marked for deletion" {
-			// Resource not found, remove from Terraform state
-			d.SetId("")
-			// Append a warning diagnostic and return
-			diags = append(diags, diag.Diagnostic{
-				Severity: diag.Warning,
-				Summary:  "Resource not found",
-				Detail:   fmt.Sprintf("Jamf Pro Distribution Point with ID '%s' was not found on the server and is marked for deletion from terraform state.", resourceID),
-			})
-			return diags
+		// Skip resource state removal if this is a create operation
+		if !d.IsNewResource() {
+			// If the error is a "not found" error, remove the resource from the state
+			if strings.Contains(err.Error(), "404") || strings.Contains(err.Error(), "410") {
+				d.SetId("") // Remove the resource from Terraform state
+				return diag.Diagnostics{
+					{
+						Severity: diag.Warning,
+						Summary:  "Resource not found",
+						Detail:   fmt.Sprintf("Jamf Pro Department resource with ID '%s' was not found and has been removed from the Terraform state.", resourceID),
+					},
+				}
+			}
 		}
-
-		// For other errors, return an error diagnostic
-		return diag.FromErr(fmt.Errorf("failed to read Jamf Pro Distribution Point with ID '%s' after retries: %v", resourceID, err))
+		// For other errors, or if this is a create operation, return a diagnostic error
+		return diag.FromErr(err)
 	}
 
 	// Update the Terraform state with the fetched data

--- a/internal/endpoints/departments/departments_resource.go
+++ b/internal/endpoints/departments/departments_resource.go
@@ -27,7 +27,7 @@ func ResourceJamfProDepartments() *schema.Resource {
 		UpdateContext: ResourceJamfProDepartmentsUpdate,
 		DeleteContext: ResourceJamfProDepartmentsDelete,
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(120 * time.Second),
+			Create: schema.DefaultTimeout(70 * time.Second),
 			Read:   schema.DefaultTimeout(30 * time.Second),
 			Update: schema.DefaultTimeout(30 * time.Second),
 			Delete: schema.DefaultTimeout(15 * time.Second),

--- a/internal/endpoints/departments/departments_resource.go
+++ b/internal/endpoints/departments/departments_resource.go
@@ -102,7 +102,7 @@ func ResourceJamfProDepartmentsCreate(ctx context.Context, d *schema.ResourceDat
 		return apiclient.Conn.GetAccountGroupByID(intID)
 	}
 
-	_, waitDiags := waitfor.ResourceIsAvailable(ctx, d, "Jamf Pro Department", creationResponse.ID, checkResourceExists, time.Duration(common.JamfProPropagationDelay)*time.Second)
+	_, waitDiags := waitfor.ResourceIsAvailable(ctx, d, "Jamf Pro Department", creationResponse.ID, checkResourceExists, time.Duration(common.DefaultPropagationTime)*time.Second, apiclient.EnableCookieJar)
 
 	if waitDiags.HasError() {
 		return waitDiags

--- a/internal/endpoints/diskencryptionconfigurations/diskencryptionconfigurations_resource.go
+++ b/internal/endpoints/diskencryptionconfigurations/diskencryptionconfigurations_resource.go
@@ -179,7 +179,7 @@ func ResourceJamfProDiskEncryptionConfigurationsCreate(ctx context.Context, d *s
 		return apiclient.Conn.GetDiskEncryptionConfigurationByID(intID)
 	}
 
-	_, waitDiags := waitfor.ResourceIsAvailable(ctx, d, "Jamf Pro Disk Encryption Configuration", strconv.Itoa(creationResponse.ID), checkResourceExists, time.Duration(common.JamfProPropagationDelay)*time.Second)
+	_, waitDiags := waitfor.ResourceIsAvailable(ctx, d, "Jamf Pro Disk Encryption Configuration", strconv.Itoa(creationResponse.ID), checkResourceExists, time.Duration(common.DefaultPropagationTime)*time.Second, apiclient.EnableCookieJar)
 	if waitDiags.HasError() {
 		return waitDiags
 	}

--- a/internal/endpoints/diskencryptionconfigurations/diskencryptionconfigurations_resource.go
+++ b/internal/endpoints/diskencryptionconfigurations/diskencryptionconfigurations_resource.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
 	"github.com/deploymenttheory/terraform-provider-jamfpro/internal/client"
+	"github.com/deploymenttheory/terraform-provider-jamfpro/internal/endpoints/common"
 	"github.com/deploymenttheory/terraform-provider-jamfpro/internal/waitfor"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -178,7 +179,7 @@ func ResourceJamfProDiskEncryptionConfigurationsCreate(ctx context.Context, d *s
 		return apiclient.Conn.GetDiskEncryptionConfigurationByID(intID)
 	}
 
-	_, waitDiags := waitfor.ResourceIsAvailable(ctx, d, "Jamf Pro Disk Encryption Configuration", strconv.Itoa(creationResponse.ID), checkResourceExists, 30*time.Second)
+	_, waitDiags := waitfor.ResourceIsAvailable(ctx, d, "Jamf Pro Disk Encryption Configuration", strconv.Itoa(creationResponse.ID), checkResourceExists, time.Duration(common.JamfProPropagationDelay)*time.Second)
 	if waitDiags.HasError() {
 		return waitDiags
 	}

--- a/internal/endpoints/diskencryptionconfigurations/diskencryptionconfigurations_resource.go
+++ b/internal/endpoints/diskencryptionconfigurations/diskencryptionconfigurations_resource.go
@@ -26,7 +26,7 @@ func ResourceJamfProDiskEncryptionConfigurations() *schema.Resource {
 		UpdateContext: ResourceJamfProDiskEncryptionConfigurationsUpdate,
 		DeleteContext: ResourceJamfProDiskEncryptionConfigurationsDelete,
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(120 * time.Second),
+			Create: schema.DefaultTimeout(70 * time.Second),
 			Read:   schema.DefaultTimeout(30 * time.Second),
 			Update: schema.DefaultTimeout(30 * time.Second),
 			Delete: schema.DefaultTimeout(15 * time.Second),

--- a/internal/endpoints/dockitems/dockitems_resource.go
+++ b/internal/endpoints/dockitems/dockitems_resource.go
@@ -26,7 +26,7 @@ func ResourceJamfProDockItems() *schema.Resource {
 		UpdateContext: ResourceJamfProDockItemsUpdate,
 		DeleteContext: ResourceJamfProDockItemsDelete,
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(120 * time.Second),
+			Create: schema.DefaultTimeout(70 * time.Second),
 			Read:   schema.DefaultTimeout(30 * time.Second),
 			Update: schema.DefaultTimeout(30 * time.Second),
 			Delete: schema.DefaultTimeout(15 * time.Second),

--- a/internal/endpoints/dockitems/dockitems_resource.go
+++ b/internal/endpoints/dockitems/dockitems_resource.go
@@ -131,7 +131,7 @@ func ResourceJamfProDockItemsCreate(ctx context.Context, d *schema.ResourceData,
 		return apiclient.Conn.GetDockItemByID(intID)
 	}
 
-	_, waitDiags := waitfor.ResourceIsAvailable(ctx, d, "Jamf Pro Dock Item", strconv.Itoa(creationResponse.ID), checkResourceExists, time.Duration(common.JamfProPropagationDelay)*time.Second)
+	_, waitDiags := waitfor.ResourceIsAvailable(ctx, d, "Jamf Pro Dock Item", strconv.Itoa(creationResponse.ID), checkResourceExists, time.Duration(common.DefaultPropagationTime)*time.Second, apiclient.EnableCookieJar)
 	if waitDiags.HasError() {
 		return waitDiags
 	}

--- a/internal/endpoints/dockitems/dockitems_resource.go
+++ b/internal/endpoints/dockitems/dockitems_resource.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
 	"github.com/deploymenttheory/terraform-provider-jamfpro/internal/client"
+	"github.com/deploymenttheory/terraform-provider-jamfpro/internal/endpoints/common"
 	"github.com/deploymenttheory/terraform-provider-jamfpro/internal/waitfor"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -130,7 +131,7 @@ func ResourceJamfProDockItemsCreate(ctx context.Context, d *schema.ResourceData,
 		return apiclient.Conn.GetDockItemByID(intID)
 	}
 
-	_, waitDiags := waitfor.ResourceIsAvailable(ctx, d, "Jamf Pro Dock Item", strconv.Itoa(creationResponse.ID), checkResourceExists, 30*time.Second)
+	_, waitDiags := waitfor.ResourceIsAvailable(ctx, d, "Jamf Pro Dock Item", strconv.Itoa(creationResponse.ID), checkResourceExists, time.Duration(common.JamfProPropagationDelay)*time.Second)
 	if waitDiags.HasError() {
 		return waitDiags
 	}

--- a/internal/endpoints/filesharedistributionpoints/filesharedistributionpoints_resource.go
+++ b/internal/endpoints/filesharedistributionpoints/filesharedistributionpoints_resource.go
@@ -28,7 +28,7 @@ func ResourceJamfProFileShareDistributionPoints() *schema.Resource {
 		DeleteContext: ResourceJamfProFileShareDistributionPointsDelete,
 		CustomizeDiff: mainCustomDiffFunc,
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(120 * time.Second),
+			Create: schema.DefaultTimeout(70 * time.Second),
 			Read:   schema.DefaultTimeout(30 * time.Second),
 			Update: schema.DefaultTimeout(30 * time.Second),
 			Delete: schema.DefaultTimeout(15 * time.Second),

--- a/internal/endpoints/filesharedistributionpoints/filesharedistributionpoints_resource.go
+++ b/internal/endpoints/filesharedistributionpoints/filesharedistributionpoints_resource.go
@@ -252,7 +252,7 @@ func ResourceJamfProFileShareDistributionPointsCreate(ctx context.Context, d *sc
 		return apiclient.Conn.GetScriptByID(id.(string))
 	}
 
-	_, waitDiags := waitfor.ResourceIsAvailable(ctx, d, "Jamf Pro Fileshare Distribution Point", creationResponse.ID, checkResourceExists, time.Duration(common.JamfProPropagationDelay)*time.Second)
+	_, waitDiags := waitfor.ResourceIsAvailable(ctx, d, "Jamf Pro Fileshare Distribution Point", creationResponse.ID, checkResourceExists, time.Duration(common.DefaultPropagationTime)*time.Second, apiclient.EnableCookieJar)
 	if waitDiags.HasError() {
 		return waitDiags
 	}

--- a/internal/endpoints/filesharedistributionpoints/filesharedistributionpoints_resource.go
+++ b/internal/endpoints/filesharedistributionpoints/filesharedistributionpoints_resource.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
 	"github.com/deploymenttheory/terraform-provider-jamfpro/internal/client"
+	"github.com/deploymenttheory/terraform-provider-jamfpro/internal/endpoints/common"
 	util "github.com/deploymenttheory/terraform-provider-jamfpro/internal/helpers/type_assertion"
 	"github.com/deploymenttheory/terraform-provider-jamfpro/internal/waitfor"
 
@@ -251,7 +252,7 @@ func ResourceJamfProFileShareDistributionPointsCreate(ctx context.Context, d *sc
 		return apiclient.Conn.GetScriptByID(id.(string))
 	}
 
-	_, waitDiags := waitfor.ResourceIsAvailable(ctx, d, "Jamf Pro Fileshare Distribution Point", creationResponse.ID, checkResourceExists, 30*time.Second)
+	_, waitDiags := waitfor.ResourceIsAvailable(ctx, d, "Jamf Pro Fileshare Distribution Point", creationResponse.ID, checkResourceExists, time.Duration(common.JamfProPropagationDelay)*time.Second)
 	if waitDiags.HasError() {
 		return waitDiags
 	}

--- a/internal/endpoints/macosconfigurationprofiles/macosconfigurationprofiles_resource.go
+++ b/internal/endpoints/macosconfigurationprofiles/macosconfigurationprofiles_resource.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
 	"github.com/deploymenttheory/terraform-provider-jamfpro/internal/client"
+	"github.com/deploymenttheory/terraform-provider-jamfpro/internal/endpoints/common"
 	"github.com/deploymenttheory/terraform-provider-jamfpro/internal/waitfor"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -470,7 +471,7 @@ func ResourceJamfProMacOSConfigurationProfilesCreate(ctx context.Context, d *sch
 		return apiclient.Conn.GetMacOSConfigurationProfileByID(intID)
 	}
 
-	_, waitDiags := waitfor.ResourceIsAvailable(ctx, d, "Jamf Pro macOS Configuration Profile", strconv.Itoa(creationResponse.ID), checkResourceExists, 45*time.Second)
+	_, waitDiags := waitfor.ResourceIsAvailable(ctx, d, "Jamf Pro macOS Configuration Profile", strconv.Itoa(creationResponse.ID), checkResourceExists, time.Duration(common.JamfProPropagationDelay)*time.Second)
 	if waitDiags.HasError() {
 		return waitDiags
 	}

--- a/internal/endpoints/macosconfigurationprofiles/macosconfigurationprofiles_resource.go
+++ b/internal/endpoints/macosconfigurationprofiles/macosconfigurationprofiles_resource.go
@@ -28,7 +28,7 @@ func ResourceJamfProMacOSConfigurationProfiles() *schema.Resource {
 		UpdateContext: ResourceJamfProMacOSConfigurationProfilesUpdate,
 		DeleteContext: ResourceJamfProMacOSConfigurationProfilesDelete,
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(120 * time.Second),
+			Create: schema.DefaultTimeout(70 * time.Second),
 			Read:   schema.DefaultTimeout(30 * time.Second),
 			Update: schema.DefaultTimeout(30 * time.Second),
 			Delete: schema.DefaultTimeout(15 * time.Second),

--- a/internal/endpoints/networksegments/networksegments_resource.go
+++ b/internal/endpoints/networksegments/networksegments_resource.go
@@ -26,7 +26,7 @@ func ResourceJamfProNetworkSegments() *schema.Resource {
 		UpdateContext: ResourceJamfProNetworkSegmentsUpdate,
 		DeleteContext: ResourceJamfProNetworkSegmentsDelete,
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(120 * time.Second),
+			Create: schema.DefaultTimeout(70 * time.Second),
 			Read:   schema.DefaultTimeout(30 * time.Second),
 			Update: schema.DefaultTimeout(30 * time.Second),
 			Delete: schema.DefaultTimeout(15 * time.Second),

--- a/internal/endpoints/networksegments/networksegments_resource.go
+++ b/internal/endpoints/networksegments/networksegments_resource.go
@@ -150,7 +150,7 @@ func ResourceJamfProNetworkSegmentsCreate(ctx context.Context, d *schema.Resourc
 		return apiclient.Conn.GetNetworkSegmentByID(intID)
 	}
 
-	_, waitDiags := waitfor.ResourceIsAvailable(ctx, d, "Jamf Pro Network Segment", strconv.Itoa(creationResponse.ID), checkResourceExists, time.Duration(common.JamfProPropagationDelay)*time.Second)
+	_, waitDiags := waitfor.ResourceIsAvailable(ctx, d, "Jamf Pro Network Segment", strconv.Itoa(creationResponse.ID), checkResourceExists, time.Duration(common.DefaultPropagationTime)*time.Second, apiclient.EnableCookieJar)
 	if waitDiags.HasError() {
 		return waitDiags
 	}

--- a/internal/endpoints/networksegments/networksegments_resource.go
+++ b/internal/endpoints/networksegments/networksegments_resource.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
 	"github.com/deploymenttheory/terraform-provider-jamfpro/internal/client"
+	"github.com/deploymenttheory/terraform-provider-jamfpro/internal/endpoints/common"
 	"github.com/deploymenttheory/terraform-provider-jamfpro/internal/waitfor"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -149,7 +150,7 @@ func ResourceJamfProNetworkSegmentsCreate(ctx context.Context, d *schema.Resourc
 		return apiclient.Conn.GetNetworkSegmentByID(intID)
 	}
 
-	_, waitDiags := waitfor.ResourceIsAvailable(ctx, d, "Jamf Pro Network Segment", strconv.Itoa(creationResponse.ID), checkResourceExists, 5*time.Second)
+	_, waitDiags := waitfor.ResourceIsAvailable(ctx, d, "Jamf Pro Network Segment", strconv.Itoa(creationResponse.ID), checkResourceExists, time.Duration(common.JamfProPropagationDelay)*time.Second)
 	if waitDiags.HasError() {
 		return waitDiags
 	}

--- a/internal/endpoints/packages/packages_resource.go
+++ b/internal/endpoints/packages/packages_resource.go
@@ -241,7 +241,7 @@ func ResourceJamfProPackagesCreate(ctx context.Context, d *schema.ResourceData, 
 		return apiclient.Conn.GetPackageByID(intID)
 	}
 
-	_, waitDiags := waitfor.ResourceIsAvailable(ctx, d, "Jamf Pro Package", strconv.Itoa(creationResponse.ID), checkResourceExists, 30*time.Second)
+	_, waitDiags := waitfor.ResourceIsAvailable(ctx, d, "Jamf Pro Package", strconv.Itoa(creationResponse.ID), checkResourceExists, 45*time.Second, false)
 	if waitDiags.HasError() {
 		return waitDiags
 	}

--- a/internal/endpoints/printers/printers_resource.go
+++ b/internal/endpoints/printers/printers_resource.go
@@ -163,7 +163,7 @@ func ResourceJamfProPrintersCreate(ctx context.Context, d *schema.ResourceData, 
 		return apiclient.Conn.GetPrinterByID(intID)
 	}
 
-	_, waitDiags := waitfor.ResourceIsAvailable(ctx, d, "Jamf Pro Printer", strconv.Itoa(creationResponse.ID), checkResourceExists, time.Duration(common.JamfProPropagationDelay)*time.Second)
+	_, waitDiags := waitfor.ResourceIsAvailable(ctx, d, "Jamf Pro Printer", strconv.Itoa(creationResponse.ID), checkResourceExists, time.Duration(common.DefaultPropagationTime)*time.Second, apiclient.EnableCookieJar)
 	if waitDiags.HasError() {
 		return waitDiags
 	}

--- a/internal/endpoints/printers/printers_resource.go
+++ b/internal/endpoints/printers/printers_resource.go
@@ -27,7 +27,7 @@ func ResourceJamfProPrinters() *schema.Resource {
 		DeleteContext: ResourceJamfProPrintersDelete,
 		CustomizeDiff: validateJamfProResourcePrinterDataFields,
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(120 * time.Second),
+			Create: schema.DefaultTimeout(70 * time.Second),
 			Read:   schema.DefaultTimeout(30 * time.Second),
 			Update: schema.DefaultTimeout(30 * time.Second),
 			Delete: schema.DefaultTimeout(15 * time.Second),

--- a/internal/endpoints/printers/printers_resource.go
+++ b/internal/endpoints/printers/printers_resource.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
 	"github.com/deploymenttheory/terraform-provider-jamfpro/internal/client"
+	"github.com/deploymenttheory/terraform-provider-jamfpro/internal/endpoints/common"
 	"github.com/deploymenttheory/terraform-provider-jamfpro/internal/waitfor"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -162,7 +163,7 @@ func ResourceJamfProPrintersCreate(ctx context.Context, d *schema.ResourceData, 
 		return apiclient.Conn.GetPrinterByID(intID)
 	}
 
-	_, waitDiags := waitfor.ResourceIsAvailable(ctx, d, "Jamf Pro Printer", strconv.Itoa(creationResponse.ID), checkResourceExists, 20*time.Second)
+	_, waitDiags := waitfor.ResourceIsAvailable(ctx, d, "Jamf Pro Printer", strconv.Itoa(creationResponse.ID), checkResourceExists, time.Duration(common.JamfProPropagationDelay)*time.Second)
 	if waitDiags.HasError() {
 		return waitDiags
 	}

--- a/internal/endpoints/scripts/scripts_resource.go
+++ b/internal/endpoints/scripts/scripts_resource.go
@@ -26,7 +26,7 @@ func ResourceJamfProScripts() *schema.Resource {
 		UpdateContext: ResourceJamfProScriptsUpdate,
 		DeleteContext: ResourceJamfProScriptsDelete,
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(120 * time.Second),
+			Create: schema.DefaultTimeout(70 * time.Second),
 			Read:   schema.DefaultTimeout(30 * time.Second),
 			Update: schema.DefaultTimeout(30 * time.Second),
 			Delete: schema.DefaultTimeout(15 * time.Second),

--- a/internal/endpoints/scripts/scripts_resource.go
+++ b/internal/endpoints/scripts/scripts_resource.go
@@ -173,7 +173,7 @@ func ResourceJamfProScriptsCreate(ctx context.Context, d *schema.ResourceData, m
 		return apiclient.Conn.GetScriptByID(id.(string))
 	}
 
-	_, waitDiags := waitfor.ResourceIsAvailable(ctx, d, "Jamf Pro Script", creationResponse.ID, checkResourceExists, time.Duration(common.JamfProPropagationDelay)*time.Second)
+	_, waitDiags := waitfor.ResourceIsAvailable(ctx, d, "Jamf Pro Script", creationResponse.ID, checkResourceExists, time.Duration(common.DefaultPropagationTime)*time.Second, apiclient.EnableCookieJar)
 	if waitDiags.HasError() {
 		return waitDiags
 	}

--- a/internal/endpoints/scripts/scripts_resource.go
+++ b/internal/endpoints/scripts/scripts_resource.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
 	"github.com/deploymenttheory/terraform-provider-jamfpro/internal/client"
+	"github.com/deploymenttheory/terraform-provider-jamfpro/internal/endpoints/common"
 	"github.com/deploymenttheory/terraform-provider-jamfpro/internal/waitfor"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -172,7 +173,7 @@ func ResourceJamfProScriptsCreate(ctx context.Context, d *schema.ResourceData, m
 		return apiclient.Conn.GetScriptByID(id.(string))
 	}
 
-	_, waitDiags := waitfor.ResourceIsAvailable(ctx, d, "Jamf Pro Script", creationResponse.ID, checkResourceExists, 10*time.Second)
+	_, waitDiags := waitfor.ResourceIsAvailable(ctx, d, "Jamf Pro Script", creationResponse.ID, checkResourceExists, time.Duration(common.JamfProPropagationDelay)*time.Second)
 	if waitDiags.HasError() {
 		return waitDiags
 	}

--- a/internal/endpoints/sites/sites_resource.go
+++ b/internal/endpoints/sites/sites_resource.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
 	"github.com/deploymenttheory/terraform-provider-jamfpro/internal/client"
+	"github.com/deploymenttheory/terraform-provider-jamfpro/internal/endpoints/common"
 	"github.com/deploymenttheory/terraform-provider-jamfpro/internal/waitfor"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -99,7 +100,7 @@ func ResourceJamfProSitesCreate(ctx context.Context, d *schema.ResourceData, met
 		return apiclient.Conn.GetSiteByID(intID)
 	}
 
-	_, waitDiags := waitfor.ResourceIsAvailable(ctx, d, "Jamf Pro Site", strconv.Itoa(creationResponse.ID), checkResourceExists, 10*time.Second)
+	_, waitDiags := waitfor.ResourceIsAvailable(ctx, d, "Jamf Pro Site", strconv.Itoa(creationResponse.ID), checkResourceExists, time.Duration(common.JamfProPropagationDelay)*time.Second)
 	if waitDiags.HasError() {
 		return waitDiags
 	}

--- a/internal/endpoints/sites/sites_resource.go
+++ b/internal/endpoints/sites/sites_resource.go
@@ -100,7 +100,7 @@ func ResourceJamfProSitesCreate(ctx context.Context, d *schema.ResourceData, met
 		return apiclient.Conn.GetSiteByID(intID)
 	}
 
-	_, waitDiags := waitfor.ResourceIsAvailable(ctx, d, "Jamf Pro Site", strconv.Itoa(creationResponse.ID), checkResourceExists, time.Duration(common.JamfProPropagationDelay)*time.Second)
+	_, waitDiags := waitfor.ResourceIsAvailable(ctx, d, "Jamf Pro Site", strconv.Itoa(creationResponse.ID), checkResourceExists, time.Duration(common.DefaultPropagationTime)*time.Second, apiclient.EnableCookieJar)
 	if waitDiags.HasError() {
 		return waitDiags
 	}

--- a/internal/endpoints/sites/sites_resource.go
+++ b/internal/endpoints/sites/sites_resource.go
@@ -26,7 +26,7 @@ func ResourceJamfProSites() *schema.Resource {
 		UpdateContext: ResourceJamfProSitesUpdate,
 		DeleteContext: ResourceJamfProSitesDelete,
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(120 * time.Second),
+			Create: schema.DefaultTimeout(70 * time.Second),
 			Read:   schema.DefaultTimeout(30 * time.Second),
 			Update: schema.DefaultTimeout(30 * time.Second),
 			Delete: schema.DefaultTimeout(15 * time.Second),

--- a/internal/endpoints/usergroups/usergroups_resource.go
+++ b/internal/endpoints/usergroups/usergroups_resource.go
@@ -267,7 +267,7 @@ func ResourceJamfProUserGroupCreate(ctx context.Context, d *schema.ResourceData,
 		return apiclient.Conn.GetUserGroupByID(intID)
 	}
 
-	_, waitDiags := waitfor.ResourceIsAvailable(ctx, d, "Jamf Pro User Group", strconv.Itoa(creationResponse.ID), checkResourceExists, time.Duration(common.JamfProPropagationDelay)*time.Second)
+	_, waitDiags := waitfor.ResourceIsAvailable(ctx, d, "Jamf Pro User Group", strconv.Itoa(creationResponse.ID), checkResourceExists, time.Duration(common.DefaultPropagationTime)*time.Second, apiclient.EnableCookieJar)
 	if waitDiags.HasError() {
 		return waitDiags
 	}

--- a/internal/endpoints/usergroups/usergroups_resource.go
+++ b/internal/endpoints/usergroups/usergroups_resource.go
@@ -43,7 +43,7 @@ func ResourceJamfProUserGroups() *schema.Resource {
 		DeleteContext: ResourceJamfProUserGroupDelete,
 		CustomizeDiff: mainCustomDiffFunc,
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(120 * time.Second),
+			Create: schema.DefaultTimeout(70 * time.Second),
 			Read:   schema.DefaultTimeout(30 * time.Second),
 			Update: schema.DefaultTimeout(30 * time.Second),
 			Delete: schema.DefaultTimeout(15 * time.Second),

--- a/internal/endpoints/usergroups/usergroups_resource.go
+++ b/internal/endpoints/usergroups/usergroups_resource.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
 	"github.com/deploymenttheory/terraform-provider-jamfpro/internal/client"
+	"github.com/deploymenttheory/terraform-provider-jamfpro/internal/endpoints/common"
 	"github.com/deploymenttheory/terraform-provider-jamfpro/internal/waitfor"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -266,7 +267,7 @@ func ResourceJamfProUserGroupCreate(ctx context.Context, d *schema.ResourceData,
 		return apiclient.Conn.GetUserGroupByID(intID)
 	}
 
-	_, waitDiags := waitfor.ResourceIsAvailable(ctx, d, "Jamf Pro User Group", strconv.Itoa(creationResponse.ID), checkResourceExists, 40*time.Second)
+	_, waitDiags := waitfor.ResourceIsAvailable(ctx, d, "Jamf Pro User Group", strconv.Itoa(creationResponse.ID), checkResourceExists, time.Duration(common.JamfProPropagationDelay)*time.Second)
 	if waitDiags.HasError() {
 		return waitDiags
 	}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -307,6 +307,9 @@ func Provider() *schema.Provider {
 		username, errUsername := GetClientUsername(d)
 		password, errPassword := GetClientPassword(d)
 
+		// extract value for httpclient build and for determining resource propagation time
+		enableCookieJar := d.Get("enable_cookie_jar").(bool)
+
 		// Check if either pair of credentials is provided, prioritizing Client ID/Secret
 		if errClientID == nil && errClientSecret == nil && clientID != "" && clientSecret != "" {
 			// Client ID and Client Secret are provided
@@ -341,7 +344,7 @@ func Provider() *schema.Provider {
 				LogOutputFormat:           d.Get("log_output_format").(string),
 				LogConsoleSeparator:       d.Get("log_console_separator").(string),
 				LogExportPath:             d.Get("log_export_path").(string),
-				EnableCookieJar:           d.Get("enable_cookie_jar").(bool),
+				EnableCookieJar:           enableCookieJar,
 				HideSensitiveData:         d.Get("hide_sensitive_data").(bool),
 				MaxRetryAttempts:          d.Get("max_retry_attempts").(int),
 				EnableDynamicRateLimiting: d.Get("enable_dynamic_rate_limiting").(bool),
@@ -362,9 +365,10 @@ func Provider() *schema.Provider {
 			return nil, diag.FromErr(err)
 		}
 
-		// Initialize your provider's APIClient struct with the Jamf Pro HTTP client.
+		// Initialize the provider's APIClient struct with the Jamf Pro HTTP client and cookie jar setting
 		jamfProAPIClient := client.APIClient{
-			Conn: httpclient,
+			Conn:            httpclient,
+			EnableCookieJar: enableCookieJar, // Allows use the cookie jar value within provider outside of the client
 		}
 
 		return &jamfProAPIClient, diags


### PR DESCRIPTION
Updated resource Create timeouts to 70seconds

Added support to the provider for a cookiejar, enabled via a new `enable_cookie_jar ` setting. This enables sticky sessions. Which when enabled, allows resources to be deployed faster due to a reduced propagation wait time of 10 seconds, however this WILL lead to increased load on a single jamf pro web application (clustered or otherwise) as it handles all Terraform CRUD operations and negates any load balancing. Consequently, deploying resources enmass (e.g creating + 10 resources at a time) can cause unpredictable resource deployment / stating errors. especially on more complex resources such as macOS config profiles. If disabled, resources adhere to Jamf Cloud's default resource propagation behaviour, incorporating a 60+1-second propagation delay before attempting to state.

Multi resource function refactoring to standardise on latest function pattern design