### PR TITLE
Bug fixes for script construction and stating of script category values

### DIFF
--- a/examples/macosconfigurationprofiles/resource.tf
+++ b/examples/macosconfigurationprofiles/resource.tf
@@ -53,3 +53,39 @@ resource "jamfpro_macos_configuration_profile" "jamfpro_macos_configuration_prof
     }
   }
 }
+
+
+resource "jamfpro_macos_configuration_profile" "jamfpro_macos_configuration_profile_001" {
+  name                = "your-macos_configuration_profile-name"
+  distribution_method = "Install Automatically" // Can be "Make Available in Self Service" or "Install Automatically"
+  user_removeable     = false
+  level               = "User" // Can be "Computer", "User", "System"
+  payload             = file("${path.module}/path/to/your.mobileconfig")
+  category {
+    id = -1 // -1 for no category or use the category resource id reference. 
+  }
+  site { // optional block
+    id   = 1
+    name = "site name"
+  }
+  scope {
+    all_computers      = false
+    computer_ids       = sort([17, 18]) // uses computer resource id
+    computer_group_ids = sort([53])     // uses computer group resource id
+    jss_user_ids       = [1, 2, 3]
+    jss_user_group_ids = [1, 2, 3]
+    building_ids       = sort([1, 2, 3])
+    department_ids     = sort([1, 2, 3])
+
+    limitations {
+      network_segment_ids = [1, 2, 3]
+      ibeacon_ids = [1, 2, 3]
+    }
+
+    exclusions {
+      network_segment_ids = [1, 2, 3]
+      ibeacon_ids = [1, 2, 3]
+      department_ids = [1, 2, 3]
+    }
+  }
+}

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.22.2
 
 // Direct
 require (
-	github.com/deploymenttheory/go-api-http-client v0.1.37
-	github.com/deploymenttheory/go-api-sdk-jamfpro v1.5.12
+	github.com/deploymenttheory/go-api-http-client v0.1.38
+	github.com/deploymenttheory/go-api-sdk-jamfpro v1.6.2
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/go-hclog v1.6.3
 	github.com/hashicorp/terraform-plugin-docs v0.19.1

--- a/go.sum
+++ b/go.sum
@@ -78,10 +78,10 @@ github.com/cyphar/filepath-securejoin v0.2.4/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxG
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/deploymenttheory/go-api-http-client v0.1.37 h1:G5ZQxj2RZwZzkmOvObiTfdkM+1Nl3K8aNmtoDld5K2g=
-github.com/deploymenttheory/go-api-http-client v0.1.37/go.mod h1:FWSFqBZbtwrP/AeWiFjoyG9PvbLF53Q1JHlrp9+5O8Q=
-github.com/deploymenttheory/go-api-sdk-jamfpro v1.5.12 h1:0Hvrz08+Co8ufI/KnfD5pHwOddIYlumLRZTy3KxOp0E=
-github.com/deploymenttheory/go-api-sdk-jamfpro v1.5.12/go.mod h1:TY9z0vZ/Mz4GYMGKo99iPfiMkceeazCH7Zu2ZyP0cIE=
+github.com/deploymenttheory/go-api-http-client v0.1.38 h1:HEk+Gjqmm3iC67g3BrLEcxpJ4ZSJ9qlrmfAqd5i9hbY=
+github.com/deploymenttheory/go-api-http-client v0.1.38/go.mod h1:FWSFqBZbtwrP/AeWiFjoyG9PvbLF53Q1JHlrp9+5O8Q=
+github.com/deploymenttheory/go-api-sdk-jamfpro v1.6.2 h1:Qh7YKXY6NpSPNjOPXf6DfYDEl64fDkJRVuTCBuaOLUw=
+github.com/deploymenttheory/go-api-sdk-jamfpro v1.6.2/go.mod h1:WhVoA8z5dwHbHLTEbzrRZVxCD+wvSJF5KGyQtVDCrJs=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=

--- a/internal/endpoints/computerextensionattributes/computerextensionattributes_object.go
+++ b/internal/endpoints/computerextensionattributes/computerextensionattributes_object.go
@@ -5,6 +5,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -27,7 +28,7 @@ func constructJamfProComputerExtensionAttribute(d *schema.ResourceData) (*jamfpr
 		inputType := jamfpro.ComputerExtensionAttributeSubsetInputType{
 			Type:     inputTypeData["type"].(string),
 			Platform: inputTypeData["platform"].(string),
-			Script:   inputTypeData["script"].(string),
+			Script:   strings.TrimSpace(inputTypeData["script"].(string)), // Trim leading/trailing whitespace on script content
 		}
 
 		// Handle "choices" within "input_type"

--- a/internal/endpoints/scripts/scripts_object.go
+++ b/internal/endpoints/scripts/scripts_object.go
@@ -14,8 +14,6 @@ import (
 func constructJamfProScript(d *schema.ResourceData) (*jamfpro.ResourceScript, error) {
 	script := &jamfpro.ResourceScript{
 		Name:           d.Get("name").(string),
-		CategoryName:   d.Get("category_name").(string),
-		CategoryId:     d.Get("category_id").(string),
 		Info:           d.Get("info").(string),
 		Notes:          d.Get("notes").(string),
 		OSRequirements: d.Get("os_requirements").(string),
@@ -28,6 +26,21 @@ func constructJamfProScript(d *schema.ResourceData) (*jamfpro.ResourceScript, er
 		Parameter9:     d.Get("parameter9").(string),
 		Parameter10:    d.Get("parameter10").(string),
 		Parameter11:    d.Get("parameter11").(string),
+	}
+
+	// Check hcl for category_name or category_id and set the appropriate default value if not set
+	categoryName, ok := d.GetOk("category_name")
+	if !ok {
+		script.CategoryName = "NONE" // Default value if not set
+	} else {
+		script.CategoryName = categoryName.(string)
+	}
+
+	categoryId, ok := d.GetOk("category_id")
+	if !ok {
+		script.CategoryId = "-1" // Default value if not set
+	} else {
+		script.CategoryId = categoryId.(string)
 	}
 
 	// Directly assign script_contents as a string

--- a/internal/endpoints/scripts/scripts_resource.go
+++ b/internal/endpoints/scripts/scripts_resource.go
@@ -45,16 +45,15 @@ func ResourceJamfProScripts() *schema.Resource {
 				Required:    true,
 				Description: "Display name for the script.",
 			},
+			"category_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The Jamf Pro unique identifier (ID) of the category.",
+			},
 			"category_name": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Computed:    true,
 				Description: "Name of the category to add the script to.",
-			},
-			"category_id": {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "The Jamf Pro unique identifier (ID) of the category.",
 			},
 			"info": {
 				Type:        schema.TypeString,

--- a/internal/endpoints/scripts/scripts_state.go
+++ b/internal/endpoints/scripts/scripts_state.go
@@ -11,12 +11,10 @@ import (
 func updateTerraformState(d *schema.ResourceData, resource *jamfpro.ResourceScript) diag.Diagnostics {
 	var diags diag.Diagnostics
 
-	// Update the Terraform state with the fetched data
+	// Update the Terraform state with the fetched data, excluding category name and category id
 	resourceData := map[string]interface{}{
 		"id":              resource.ID,
 		"name":            resource.Name,
-		"category_name":   resource.CategoryName,
-		"category_id":     resource.CategoryId,
 		"info":            resource.Info,
 		"notes":           resource.Notes,
 		"os_requirements": resource.OSRequirements,
@@ -36,6 +34,19 @@ func updateTerraformState(d *schema.ResourceData, resource *jamfpro.ResourceScri
 	for key, val := range resourceData {
 		if err := d.Set(key, val); err != nil {
 			return diag.FromErr(err)
+		}
+	}
+
+	// Set category_name and category_id in the state only if they are not default values
+	if resource.CategoryName != "NONE" {
+		if err := d.Set("category_name", resource.CategoryName); err != nil {
+			diags = append(diags, diag.FromErr(err)...)
+		}
+	}
+
+	if resource.CategoryId != "-1" {
+		if err := d.Set("category_id", resource.CategoryId); err != nil {
+			diags = append(diags, diag.FromErr(err)...)
 		}
 	}
 


### PR DESCRIPTION
bug fixes for object construction that now no longer requires a category field to be defined in a script resource and bug fixes also for `category_id` and `category_name` so that they are only stated if they are not default values. i.e not `-1` and `NONE` respectively.