### PR TITLE
chore: Set some default values for computerextensionattributes resource

### DIFF
--- a/internal/endpoints/computerextensionattributes/computerextensionattributes_resource.go
+++ b/internal/endpoints/computerextensionattributes/computerextensionattributes_resource.go
@@ -61,7 +61,8 @@ func ResourceJamfProComputerExtensionAttributes() *schema.Resource {
 			"data_type": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				Description:  "Data type of the computer extension attribute. Can be String / Integer / Date (YYYY-MM-DD hh:mm:ss)",
+				Default:      "String",
+				Description:  "Data type of the computer extension attribute. Can be String / Integer / Date (YYYY-MM-DD hh:mm:ss). Value defaults to `String`.",
 				ValidateFunc: validation.StringInSlice([]string{"String", "Integer", "Date"}, false),
 			},
 			"input_type": {
@@ -101,7 +102,8 @@ func ResourceJamfProComputerExtensionAttributes() *schema.Resource {
 			"inventory_display": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				Description:  "Display details for inventory for the computer extension attribute.",
+				Default:      "General",
+				Description:  "Display details for inventory for the computer extension attribute. Value defaults to `General`.",
 				ValidateFunc: validation.StringInSlice([]string{"General", "Hardware", "Operating System", "User and Location", "Purchasing", "Extension Attributes"}, false),
 			},
 			"recon_display": {


### PR DESCRIPTION
The attributes `data_type` and `inventory_display` in the computerextensionattributes have default values and are reflected in the terraform schema.

The following is the simplest example of checking default values.

```sh
$ curl -X 'POST' \
  'https://example.jamfcloud.com/JSSResource/computerextensionattributes/id/0' \
  -H 'accept: application/xml' \
  -H 'Authorization: Bearer token' \
  -H 'Content-type: application/xml' \
  -d '<computer_extension_attribute><name>test for terraform</name></computer_extension_attribute>'

<?xml version="1.0" encoding="UTF-8"?>
<computer_extension_attribute>
  <id>35</id>
</computer_extension_attribute>

$ curl -X 'GET' \
  'https://exmaple.jamfcloud.com/JSSResource/computerextensionattributes/id/35' \
  -H 'accept: application/xml' \
  -H 'Authorization: Bearer token'

<?xml version="1.0" encoding="UTF-8"?>
<computer_extension_attribute>
  <id>35</id>
  <name>test for terraform</name>
  <enabled>true</enabled>
  <description/>
  <data_type>String</data_type>
  <input_type>
    <type>Text Field</type>
  </input_type>
  <inventory_display/>
</computer_extension_attribute>
```
