### PR TITLE
Update apiroles_resource.go

### DIFF
--- a/internal/endpoints/apiroles/apiroles_resource.go
+++ b/internal/endpoints/apiroles/apiroles_resource.go
@@ -105,7 +105,7 @@ func ResourceJamfProAPIRolesCreate(ctx context.Context, d *schema.ResourceData, 
 		if err != nil {
 			return nil, fmt.Errorf("error converting ID '%v' to integer: %v", id, err)
 		}
-		return apiclient.Conn.GetAccountGroupByID(intID)
+		return apiclient.Conn.GetJamfApiRoleByID(intID)
 	}
 
 	_, waitDiags := waitfor.ResourceIsAvailable(ctx, d, "Jamf Pro API Role", creationResponse.ID, checkResourceExists, time.Duration(common.DefaultPropagationTime)*time.Second, apiclient.EnableCookieJar)


### PR DESCRIPTION
Resource creation validation for API roles fails due to the wrong API endpoint being hit. The current version looks for account groups rather than API roles. This fixes validation to use the correct endpoint.

Fixes #208 