### PR TITLE
Computer groups bug

### DIFF
--- a/.github/workflows/code-check-and-tests.yaml
+++ b/.github/workflows/code-check-and-tests.yaml
@@ -72,7 +72,11 @@ jobs:
         with:
           go-version-file: 'go.mod'
           cache: true
-      - run: make golangcilint
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          args: --timeout=5m --config=/my/path/.golangci.yml
+          version: v1.58
   generate:
     name: go generate
     needs: [build]

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -6,10 +6,8 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4.1.1
-      with:
-        ref: ${{ github.event.pull_request.head.ref }}
-
+    - name: Checkout Source
+      uses: actions/checkout@v4.1.1
     - name: Render terraform docs and push changes back to PR
       uses: terraform-docs/gh-actions@main
       with:

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,6 +1,35 @@
+DEV      := deploymenttheory
+PROVIDER := jamfpro
+VERSION  := $(shell git describe --abbrev=0 --tags --match "v*")
+PLUGINS  := ${HOME}/bin/plugins/registry.terraform.io/${DEV}/${PROVIDER}
+BIN      := terraform-provider-jamfpro_${VERSION}
+
+define TERRAFORMRC
+provider_installation {
+  dev_overrides {
+    "${DEV}/${PROVIDER}" = "${PLUGINS}"
+  }
+}
+endef
+
 default: testacc
 
 # Run acceptance tests
 .PHONY: testacc
 testacc:
 	TF_ACC=1 go test ./... -v $(TESTARGS) -timeout 120m
+
+# Run go build. Output to dist/.
+.PHONY: build
+.SILENT: build
+build:
+	mkdir -p dist
+	go build -o dist/${BIN} .
+
+# Run go build. Move artifact to terraform plugins dir. Output override config for ~/.terraformrc
+.PHONY: install
+.SILENT: install
+install: build
+	mkdir -p ${PLUGINS}
+	mv dist/${BIN} ${PLUGINS}/${BIN}
+	$(info ${TERRAFORMRC})

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -5,11 +5,15 @@ PLUGINS  := ${HOME}/bin/plugins/registry.terraform.io/${DEV}/${PROVIDER}
 BIN      := terraform-provider-jamfpro_${VERSION}
 
 define TERRAFORMRC
+
+add the following config to ~/.terraformrc to enable override:
+```
 provider_installation {
   dev_overrides {
     "${DEV}/${PROVIDER}" = "${PLUGINS}"
   }
 }
+```
 endef
 
 default: testacc
@@ -21,15 +25,17 @@ testacc:
 
 # Run go build. Output to dist/.
 .PHONY: build
-.SILENT: build
 build:
-	mkdir -p dist
+	@mkdir -p dist
 	go build -o dist/${BIN} .
+
+# Run go build. Output to dist/.
+.PHONY: build_override
+build_override: build
+	mkdir -p ${PLUGINS}
+	mv dist/${BIN} ${PLUGINS}/${BIN}
 
 # Run go build. Move artifact to terraform plugins dir. Output override config for ~/.terraformrc
 .PHONY: install
-.SILENT: install
-install: build
-	mkdir -p ${PLUGINS}
-	mv dist/${BIN} ${PLUGINS}/${BIN}
+install: build_override
 	$(info ${TERRAFORMRC})

--- a/internal/endpoints/apiroles/apiroles_resource.go
+++ b/internal/endpoints/apiroles/apiroles_resource.go
@@ -108,7 +108,7 @@ func ResourceJamfProAPIRolesCreate(ctx context.Context, d *schema.ResourceData, 
 		if err != nil {
 			return nil, fmt.Errorf("error converting ID '%v' to integer: %v", id, err)
 		}
-		return apiclient.Conn.GetJamfApiRoleByID(string(intID))
+		return apiclient.Conn.GetJamfApiRoleByID(strconv.Itoa(intID))
 	}
 
 	_, waitDiags := waitfor.ResourceIsAvailable(ctx, d, "Jamf Pro API Role", creationResponse.ID, checkResourceExists, time.Duration(common.DefaultPropagationTime)*time.Second, apiclient.EnableCookieJar)

--- a/internal/endpoints/apiroles/apiroles_resource.go
+++ b/internal/endpoints/apiroles/apiroles_resource.go
@@ -108,7 +108,7 @@ func ResourceJamfProAPIRolesCreate(ctx context.Context, d *schema.ResourceData, 
 		if err != nil {
 			return nil, fmt.Errorf("error converting ID '%v' to integer: %v", id, err)
 		}
-		return apiclient.Conn.GetJamfApiRoleByID(intID)
+		return apiclient.Conn.GetJamfApiRoleByID(string(intID))
 	}
 
 	_, waitDiags := waitfor.ResourceIsAvailable(ctx, d, "Jamf Pro API Role", creationResponse.ID, checkResourceExists, time.Duration(common.DefaultPropagationTime)*time.Second, apiclient.EnableCookieJar)

--- a/internal/endpoints/computergroups/computergroups_data_validation.go
+++ b/internal/endpoints/computergroups/computergroups_data_validation.go
@@ -21,7 +21,7 @@ func customDiffComputeGroups(ctx context.Context, d *schema.ResourceDiff, meta i
 	return nil
 }
 
-// validateComputersNotAllowedWithSmart checks that 'computers' is not set when 'is_smart' is true.
+// validateComputersNotAllowedWithSmart checks that 'computers' is not set when 'is_smart' is true and a site is set
 func validateComputersNotAllowedWithSmart(_ context.Context, d *schema.ResourceDiff, _ interface{}) error {
 	isSmart := d.Get("is_smart").(bool)
 	site := d.Get("site").([]interface{})[0].(map[string]interface{})

--- a/internal/endpoints/computergroups/computergroups_data_validation.go
+++ b/internal/endpoints/computergroups/computergroups_data_validation.go
@@ -24,9 +24,10 @@ func customDiffComputeGroups(ctx context.Context, d *schema.ResourceDiff, meta i
 // validateComputersNotAllowedWithSmart checks that 'computers' is not set when 'is_smart' is true.
 func validateComputersNotAllowedWithSmart(_ context.Context, d *schema.ResourceDiff, _ interface{}) error {
 	isSmart := d.Get("is_smart").(bool)
-	if isSmart {
+	site := d.Get("site").([]interface{})[0].(map[string]interface{})
+	if isSmart && site["id"] != -1 {
 		if computers, exists := d.GetOk("computers"); exists && len(computers.([]interface{})) > 0 {
-			return fmt.Errorf("'computers' field is not allowed when 'is_smart' is true")
+			return fmt.Errorf("'computers' field is not allowed when 'is_smart' is true %v", site)
 		}
 	}
 	return nil

--- a/internal/endpoints/computergroups/computergroups_data_validation.go
+++ b/internal/endpoints/computergroups/computergroups_data_validation.go
@@ -27,7 +27,7 @@ func validateComputersNotAllowedWithSmart(_ context.Context, d *schema.ResourceD
 	site := d.Get("site").([]interface{})[0].(map[string]interface{})
 	if isSmart && site["id"] != -1 {
 		if computers, exists := d.GetOk("computers"); exists && len(computers.([]interface{})) > 0 {
-			return fmt.Errorf("'computers' field is not allowed when 'is_smart' is true %v", site)
+			return fmt.Errorf("'computers' field is not allowed when 'is_smart' is true")
 		}
 	}
 	return nil


### PR DESCRIPTION
* Adds `install` and `build_override` rules to makefile.

I've been using these during local dev to make my life easier. The idea is to run `make install` to quickly update the local build. Rule also outputs the required ~/.terraformrc override config with correct path.

* Fixes a type error I see when trying to compile main:
```
internal/endpoints/apiroles/apiroles_resource.go:111:44: cannot use intID (variable of type int) as string value in argument to apiclient.Conn.GetJamfApiRoleByID
make: *** [build] Error 1
```

* Updates the computergroup validation function to accept a computers array when isSmart is true but no site is defined. 

This matches the logic used when updating state, explicated by [this comment](https://github.com/deploymenttheory/terraform-provider-jamfpro/blob/1e3f07cae2cdba7521ec0223662ddd121beaccb9/internal/endpoints/computergroups/computergroups_state.go#L54). As of now, I can't update to 0.52 because this validation fails solely from reading extant state 🤕.