### PR TITLE
Uncomment `name` Attribute within Category

### DIFF
--- a/internal/endpoints/common/sharedschemas/category.go
+++ b/internal/endpoints/common/sharedschemas/category.go
@@ -10,11 +10,11 @@ func GetSharedSchemaCategory() *schema.Resource {
 				Required:    true,
 				Description: "The unique identifier of the category to which the configuration profile is scoped.",
 			},
-			// "name": {
-			// 	Type:        schema.TypeString,
-			// 	Optional:    true,
-			// 	Description: "The name of the category to which the configuration profile is scoped.",
-			// },
+			"name": {
+				Type:        schema.TypeString,
+			 	Optional:    true,
+			 	Description: "The name of the category to which the configuration profile is scoped.",
+			},
 		},
 	}
 


### PR DESCRIPTION
While removing the name attribute might be good from a referencing perspective, simply commenting it out breaks the state for any existing users when upgrading to this version of the provider. 

Suggest this is uncommented until a state migration can be implemented, then removing the attribute.