### PR TITLE
Update advanced_computer_search.md

### DIFF
--- a/docs/resources/advanced_computer_search.md
+++ b/docs/resources/advanced_computer_search.md
@@ -42,9 +42,6 @@ Required:
 - `name` (String)
 - `search_type` (String)
 - `value` (String)
-
-Optional:
-
 - `and_or` (String)
 - `closing_paren` (Boolean)
 - `opening_paren` (Boolean)


### PR DESCRIPTION
All fields in Criteria are required for advanced computer search (if provided). Contrast to computer groups where some are optional