### PR TITLE
add (back) hasSite check to comp group data validation

### DIFF
--- a/internal/endpoints/computergroups/computergroups_data_validation.go
+++ b/internal/endpoints/computergroups/computergroups_data_validation.go
@@ -23,9 +23,16 @@ func customDiffComputeGroups(ctx context.Context, d *schema.ResourceDiff, meta i
 
 // validateComputersNotAllowedWithSmart checks that 'computers' is not set when 'is_smart' is true and a site is set
 func validateComputersNotAllowedWithSmart(_ context.Context, d *schema.ResourceDiff, _ interface{}) error {
+	var hasSite bool
+	site := d.Get("site").([]interface{})
+	if len(site) == 1 {
+		hasSite = site[0].(map[string]interface{})["id"] != -1
+	} else {
+		hasSite = len(site) > 0
+	}
 	isSmart := d.Get("is_smart").(bool)
 
-	if isSmart {
+	if isSmart && hasSite {
 		if computers, ok := d.GetOk("computers"); ok {
 			if len(computers.([]interface{})) > 0 {
 				return fmt.Errorf("'computers' field not allowed when is_smart is true")


### PR DESCRIPTION
Intended to address the issue described [here](https://github.com/deploymenttheory/terraform-provider-jamfpro/issues/228#issuecomment-2128602653).

This restores a site check to computer groups validation. I've amended the logic so that we shouldn't see any list index exceptions when/if `site` is entirely empty.

I'm not really sure of several things:

* Is this error solely due to these groups + my tf state having been created by a prior version of the provider (0.0.49)?
* Why are computers expected when `site` is not defined, anyways? Can't we just discard them?
* Why aren't I seeing a populated computers array in state, if they exist in the schema diff? I'd been assuming that if the error didn't occur, they'd appear after an apply.
* Are we using CustomizeDiff correctly?
* Why was the 'fix' reverted in the first place (asked humbly)? My assumption is because of the exception I'm now trying to avoid*, but perhaps there's some other cause?

\* That exception:

```
panic: runtime error: index out of range [0] with length 0

goroutine 430 [running]:
github.com/deploymenttheory/terraform-provider-jamfpro/internal/endpoints/computergroups.validateComputersNotAllowedWithSmart({0x0?, 0x0?}, 0x1400074c680, {0x0?, 0x0?})
	/Users/w0de/src/terraform-provider-jamfpro-w0de/internal/endpoints/computergroups/computergroups_data_validation.go:27 +0x1b8
github.com/deploymenttheory/terraform-provider-jamfpro/internal/endpoints/computergroups.customDiffComputeGroups({0x101b86890, 0x14000eb1b90}, 0x1400074c680, {0x101924e60, 0x14000156620})
	/Users/w0de/src/terraform-provider-jamfpro-w0de/internal/endpoints/computergroups/computergroups_data_validation.go:13 +0x30
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.schemaMap.Diff(0x1400043c3c0, {0x101b86890, 0x14000eb1b90}, 0x1400079b6c0, 0x14000549130, 0x101b6d2d0, {0x101924e60, 0x14000156620}, 0x0)
	/Users/w0de/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.33.0/helper/schema/schema.go:698 +0x3b8
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).SimpleDiff(0x101b86af8?, {0x101b86890?, 0x14000eb1b90?}, 0x1400079b6c0, 0x14000eb1bc0?, {0x101924e60?, 0x14000156620?})
	/Users/w0de/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.33.0/helper/schema/resource.go:962 +0x9c
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).PlanResourceChange(0x140003fe720, {0x101b86890?, 0x14000eb1ad0?}, 0x14000548af0)
	/Users/w0de/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.33.0/helper/schema/grpc_provider.go:798 +0x824
github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server.(*server).PlanResourceChange(0x140003fc0a0, {0x101b86890?, 0x14000eb12f0?}, 0x1400064c700)
	/Users/w0de/go/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.22.0/tfprotov5/tf5server/server.go:811 +0x2b4
github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_PlanResourceChange_Handler({0x101b326e0, 0x140003fc0a0}, {0x101b86890, 0x14000eb12f0}, 0x1400089a680, 0x0)
	/Users/w0de/go/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.22.0/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:500 +0x1c0
google.golang.org/grpc.(*Server).processUnaryRPC(0x140001dd200, {0x101b86890, 0x14000eb1260}, {0x101b8c940, 0x14000427ba0}, 0x140009777a0, 0x1400043d7a0, 0x102424520, 0x0)
	/Users/w0de/go/pkg/mod/google.golang.org/grpc@v1.61.1/server.go:1385 +0xb40
google.golang.org/grpc.(*Server).handleStream(0x140001dd200, {0x101b8c940, 0x14000427ba0}, 0x140009777a0)
	/Users/w0de/go/pkg/mod/google.golang.org/grpc@v1.61.1/server.go:1796 +0xc00
google.golang.org/grpc.(*Server).serveStreams.func2.1()
	/Users/w0de/go/pkg/mod/google.golang.org/grpc@v1.61.1/server.go:1029 +0x8c
created by google.golang.org/grpc.(*Server).serveStreams.func2 in goroutine 15
	/Users/w0de/go/pkg/mod/google.golang.org/grpc@v1.61.1/server.go:1040 +0x13c
```