### PR TITLE
Update policies_state.go

### DIFF
--- a/internal/endpoints/policies/policies_state.go
+++ b/internal/endpoints/policies/policies_state.go
@@ -393,6 +393,10 @@ func prepStatePayloadPackages(out *[]map[string]interface{}, resp *jamfpro.Resou
 	if resp.PackageConfiguration == nil {
 		return
 	}
+	//packages can be nil but deployment state default
+	if resp.PackageConfiguration.Packages == nil {
+		return
+	}
 
 	(*out)[0]["packages"] = make([]map[string]interface{}, 0)
 	for _, v := range *resp.PackageConfiguration.Packages {


### PR DESCRIPTION
Possible fix for [#271](https://github.com/deploymenttheory/terraform-provider-jamfpro/issues/271)

[PolicySubsetPackageConfiguration](https://github.com/deploymenttheory/go-api-sdk-jamfpro/blob/b961e54feed8363ee36faa8dbe5fe093a6a8e524/sdk/jamfpro/classicapi_policies.go#L172) is a struct which can have policies as nil but not the parent struct 