### PR TITLE
Fixes for update function within packages + new example

### DIFF
--- a/examples/packages/resource.tf
+++ b/examples/packages/resource.tf
@@ -1,17 +1,24 @@
 // Definition a Jamf Pro Package Resource
-resource "jamfpro_package" "jamfpro_package_001" {
-  name                          = "tf-example-package-your-package-name"
-  package_file_path             = file("path/to/your.pkg")
-  category                      = "" // Optional / can be explitly set or a reference to a jamfpro_category resource e.g jamfpro_category.jamfpro_category_001.name
-  info                          = "tf package deployment for demonstration"
-  notes                         = "This package is used for Terraform provider documentation example."
-  priority                      = 10
-  reboot_required               = false
-  fill_user_template            = false // Optional for .dmg files only
-  fill_existing_users           = false // Optional for .dmg files only
-  boot_volume_required          = false
-  allow_uninstalled             = false
-  os_requirements               = "macOS 10.15.7, macOS 11.1"
-  install_if_reported_available = false
-  send_notification             = true
+resource "jamfpro_package" "jamfpro_package_002" {
+  package_name                  = "your-package-name" // Required
+  package_file_path             = "/path/to/your/package/file/.pkg or .dmg" // Required
+  category_id                   = "your-category-id" // Required /  jamfpro_category.jamfpro_category_001.id
+  info                          = "tf package deployment for demonstration" // Optional
+  notes                         = "Uploaded by: terraform-provider-jamfpro plugin." // Optional
+  priority                      = 10 // Required
+  reboot_required               = true // Required
+  fill_user_template            = false // Required
+  fill_existing_users           = false // Required
+  os_requirements               = "macOS 10.15.7, macOS 11.1" // Required
+  swu                           = false // optional
+  self_heal_notify              = false // optional
+  os_install                    = false // Required
+  serial_number                 = "" // optional
+  suppress_updates              = false // Required
+  ignore_conflicts              = false
+  suppress_from_dock            = false // Required
+  suppress_eula                 = false // Required
+  suppress_registration         = false // Required
+  manifest                      = ""
+  manifest_file_name            = ""
 }

--- a/examples/packages/resource.tf
+++ b/examples/packages/resource.tf
@@ -21,4 +21,7 @@ resource "jamfpro_package" "jamfpro_package_002" {
   suppress_registration         = false // Required
   manifest                      = ""
   manifest_file_name            = ""
+  timeouts {
+    create                      = "90m" // Optional / Useful for large packages uploads
+  }
 }

--- a/internal/endpoints/packages/packages_resource.go
+++ b/internal/endpoints/packages/packages_resource.go
@@ -10,10 +10,10 @@ import (
 // ResourceJamfProPackages defines the schema and CRUD operations for managing Jamf Pro Packages in Terraform.
 func ResourceJamfProPackages() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: ResourceJamfProPackagesCreate,
-		ReadContext:   ResourceJamfProPackagesRead,
-		UpdateContext: ResourceJamfProPackagesUpdate,
-		DeleteContext: ResourceJamfProPackagesDelete,
+		CreateContext: resourceJamfProPackagesCreate,
+		ReadContext:   resourceJamfProPackagesRead,
+		UpdateContext: resourceJamfProPackagesUpdate,
+		DeleteContext: resourceJamfProPackagesDelete,
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(45 * time.Minute),
 			Read:   schema.DefaultTimeout(15 * time.Second),

--- a/internal/endpoints/packages/packages_resource.go
+++ b/internal/endpoints/packages/packages_resource.go
@@ -11,13 +11,13 @@ import (
 func ResourceJamfProPackages() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceJamfProPackagesCreate,
-		ReadContext:   resourceJamfProPackagesRead,
+		ReadContext:   resourceJamfProPackagesReadWithCleanup,
 		UpdateContext: resourceJamfProPackagesUpdate,
 		DeleteContext: resourceJamfProPackagesDelete,
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(45 * time.Minute),
 			Read:   schema.DefaultTimeout(15 * time.Second),
-			Update: schema.DefaultTimeout(31 * time.Minute),
+			Update: schema.DefaultTimeout(45 * time.Minute),
 			Delete: schema.DefaultTimeout(15 * time.Second),
 		},
 		CustomizeDiff: customValidateFilePath,

--- a/internal/endpoints/scripts/scripts_crud.go
+++ b/internal/endpoints/scripts/scripts_crud.go
@@ -52,14 +52,12 @@ func resourceJamfProScriptsCreate(ctx context.Context, d *schema.ResourceData, m
 // 1. Fetches the script's current state using its ID. If it fails then obtain script's current state using its Name.
 // 2. Updates the Terraform state with the fetched data to ensure it accurately reflects the current state in Jamf Pro.
 // 3. Handles any discrepancies, such as the script being deleted outside of Terraform, to keep the Terraform state synchronized.
-
 func resourceJamfProScriptsRead(ctx context.Context, d *schema.ResourceData, meta interface{}, cleanup bool) diag.Diagnostics {
 	client := meta.(*jamfpro.Client)
 	resourceID := d.Id()
 	var diags diag.Diagnostics
 
 	var response *jamfpro.ResourceScript
-	log.Println("LOGHERE")
 	log.Println(schema.TimeoutRead)
 	err := retry.RetryContext(ctx, d.Timeout(schema.TimeoutRead), func() *retry.RetryError {
 		var apiErr error


### PR DESCRIPTION
changed function flow to update package metadata first and then upload package if md5 hash differs selectively