### PR TITLE
fix key name (users -> assigned_user_ids) in user groups validator func

### DIFF
--- a/internal/resources/usergroups/usergroups_data_validator.go
+++ b/internal/resources/usergroups/usergroups_data_validator.go
@@ -30,7 +30,7 @@ func validateIsSmartAttribute(_ context.Context, diff *schema.ResourceDiff, _ in
 		return nil
 	}
 
-	usersBlockExists := len(diff.Get("users").([]interface{})) > 0
+	usersBlockExists := len(diff.Get("assigned_user_ids").([]interface{})) > 0
 	criteriaBlockExists := len(diff.Get("criteria").([]interface{})) > 0
 
 	if isSmart.(bool) && usersBlockExists {


### PR DESCRIPTION
Seems this reference wasn't updated when the user group resource was updated. Causes the following crash:


```
Stack trace from the terraform-provider-jamfpro_v0.1.5 plugin:

panic: interface conversion: interface {} is nil, not []interface {}

goroutine 504 [running]:
github.com/deploymenttheory/terraform-provider-jamfpro/internal/endpoints/usergroups.validateIsSmartAttribute({0x0?, 0x0?}, 0x140008861c0, {0x0?, 0x0?})
	github.com/deploymenttheory/terraform-provider-jamfpro/internal/endpoints/usergroups/usergroups_data_validator.go:33 +0x288
github.com/deploymenttheory/terraform-provider-jamfpro/internal/endpoints/usergroups.mainCustomDiffFunc({0x101429880, 0x14000904420}, 0x140008861c0, {0x10140d3a0, 0x14000268560})
	github.com/deploymenttheory/terraform-provider-jamfpro/internal/endpoints/usergroups/usergroups_data_validator.go:13 +0x30
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.schemaMap.Diff(0x140004994a0, {0x101429880, 0x14000904420}, 0x140007a5a00, 0x140007643c0, 0x101410688, {0x10140d3a0, 0x14000268560}, 0x0)
	github.com/hashicorp/terraform-plugin-sdk/v2@v2.34.0/helper/schema/schema.go:698 +0x3b8
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).SimpleDiff(0x101429d38?, {0x101429880?, 0x14000904420?}, 0x140007a5a00, 0x14000904450?, {0x10140d3a0?, 0x14000268560?})
	github.com/hashicorp/terraform-plugin-sdk/v2@v2.34.0/helper/schema/resource.go:990 +0x9c
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).PlanResourceChange(0x140003d4858, {0x101429880?, 0x14000904360?}, 0x1400020d9f0)
	github.com/hashicorp/terraform-plugin-sdk/v2@v2.34.0/helper/schema/grpc_provider.go:858 +0xa30
github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server.(*server).PlanResourceChange(0x140002dd680, {0x101429880?, 0x14000b8ba40?}, 0x140009ac800)
	github.com/hashicorp/terraform-plugin-go@v0.23.0/tfprotov5/tf5server/server.go:825 +0x2c8
github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_PlanResourceChange_Handler({0x1013d66a0, 0x140002dd680}, {0x101429880, 0x14000b8ba40}, 0x140009ac780, 0x0)
	github.com/hashicorp/terraform-plugin-go@v0.23.0/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:500 +0x1c0
google.golang.org/grpc.(*Server).processUnaryRPC(0x140001c5000, {0x101429880, 0x14000b8b9b0}, {0x10142f9a0, 0x140002c4000}, 0x140007df440, 0x14000499740, 0x101ca3d80, 0x0)
	google.golang.org/grpc@v1.63.2/server.go:1369 +0xb58
google.golang.org/grpc.(*Server).handleStream(0x140001c5000, {0x10142f9a0, 0x140002c4000}, 0x140007df440)
	google.golang.org/grpc@v1.63.2/server.go:1780 +0xb20
google.golang.org/grpc.(*Server).serveStreams.func2.1()
	google.golang.org/grpc@v1.63.2/server.go:1019 +0x8c
created by google.golang.org/grpc.(*Server).serveStreams.func2 in goroutine 65
	google.golang.org/grpc@v1.63.2/server.go:1030 +0x13c
```