### PR TITLE
update scripts by ID, not name

### DIFF
--- a/internal/resources/scripts/crud.go
+++ b/internal/resources/scripts/crud.go
@@ -50,7 +50,7 @@ func update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.
 		d,
 		meta,
 		construct,
-		meta.(*jamfpro.Client).UpdateScriptByName,
+		meta.(*jamfpro.Client).UpdateScriptByID,
 		readNoCleanup,
 	)
 }


### PR DESCRIPTION
Passing name causes updates to fail, since `common.Update` passes the resource ID as name parameter. Even if it passed the resource's name value, using name as a unique ID would be undesirable, no? [This was the case in previous iteration](https://github.com/deploymenttheory/terraform-provider-jamfpro/commit/c0f125beb9339a39fe3d0a7bb8f734788b88a735#diff-d19a7abf865960388fbd11af0555e09338cde6c348f25de9f60cbf11e3ed0e45L97).


```
Error: -30T01:29:44.232Z [ERROR] provider.terraform-provider-jamfpro_v0.1.6-w0de+4: Context cancelation detected, abandoning grace period: timestamp=2024-07-30T01:29:44.232Z
Error: -30T01:29:44.233Z [ERROR] provider.terraform-provider-jamfpro_v0.1.6-w0de+4: Response contains error diagnostic: @module=sdk.proto tf_rpc=ApplyResourceChange @caller=github.com/hashicorp/terraform-plugin-go@v0.23.0/tfprotov5/internal/diag/diagnostics.go:58 diagnostic_detail="" tf_proto_version=5.6 diagnostic_severity=ERROR diagnostic_summary="failed to update Jamf pro  (ID: 23) after retries: failed to get script by name: 23, error: failed to get script by name: 23, error: resource with name does not exist" tf_provider_addr=provider tf_req_id=d342cd1c-893c-4438-0a5a-9c48a4d10304 tf_resource_type=jamfpro_script timestamp=2024-07-30T01:29:44.233Z
Error: -30T01:29:44.236Z [ERROR] vertex "jamfpro_script.loggedinuser" error: failed to update Jamf pro  (ID: 23) after retries: failed to get script by name: 23, error: failed to get script by name: 23, error: resource with name does not exist
```