### PR TITLE
Fixed a bug in handling default values using environment variables

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -241,13 +241,13 @@ func Provider() *schema.Provider {
 			"jamfpro_instance_fqdn": {
 				Type:        schema.TypeString,
 				Required:    true,
-				DefaultFunc: schema.EnvDefaultFunc(envVarJamfProFQDN, ""),
+				DefaultFunc: schema.EnvDefaultFunc(envVarJamfProFQDN, nil),
 				Description: "The Jamf Pro FQDN (fully qualified domain name). example: https://mycompany.jamfcloud.com",
 			},
 			"auth_method": {
 				Type:        schema.TypeString,
 				Required:    true,
-				DefaultFunc: schema.EnvDefaultFunc(envVarJamfProAuthMethod, ""),
+				DefaultFunc: schema.EnvDefaultFunc(envVarJamfProAuthMethod, nil),
 				Description: "Auth method chosen for Jamf.",
 				ValidateFunc: validation.StringInSlice([]string{
 					"basic", "oauth2",
@@ -256,27 +256,27 @@ func Provider() *schema.Provider {
 			"client_id": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc(envVarOAuthClientId, ""),
+				DefaultFunc: schema.EnvDefaultFunc(envVarOAuthClientId, nil),
 				Description: "The Jamf Pro Client ID for authentication when auth_method is 'oauth2'.",
 			},
 			"client_secret": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Sensitive:   true,
-				DefaultFunc: schema.EnvDefaultFunc(envVarOAuthClientSecret, ""),
+				DefaultFunc: schema.EnvDefaultFunc(envVarOAuthClientSecret, nil),
 				Description: "The Jamf Pro Client secret for authentication when auth_method is 'oauth2'.",
 			},
 			"basic_auth_username": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc(envVarBasicAuthUsername, ""),
+				DefaultFunc: schema.EnvDefaultFunc(envVarBasicAuthUsername, nil),
 				Description: "The Jamf Pro username used for authentication when auth_method is 'basic'.",
 			},
 			"basic_auth_password": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Sensitive:   true,
-				DefaultFunc: schema.EnvDefaultFunc(envVarBasicAuthPassword, ""),
+				DefaultFunc: schema.EnvDefaultFunc(envVarBasicAuthPassword, nil),
 				Description: "The Jamf Pro password used for authentication when auth_method is 'basic'.",
 			},
 			"enable_client_sdk_logs": {


### PR DESCRIPTION
## Motivation

I want to use the value passed in the provider block.

## Actual Behavior

For attributes that are designed to take an environment variable as their default value, if the environment variable is not set, it will always be an empty string and the value passed in the provider block will not be used.

```tf
variable "jamfpro_client_id" {
  type        = string
  description = "Jamf Pro API Client ID"
}

variable "jamfpro_client_secret" {
  type        = string
  description = "Jamf Pro API Client Secret"
  sensitive   = true
}

provider "jamfpro" {
  jamfpro_instance_fqdn      = "https://xxxx.jamfcloud.com"
  client_id                  = var.jamfpro_client_id
  client_secret              = var.jamfpro_client_secret
}
```

```sh
$ terraform plan
var.jamfpro_client_id
  Jamf Pro API Client ID

  Enter a value: xxxxxxxxxxxxxxxxx

var.jamfpro_client_secret
  Jamf Pro API Client Secret

  Enter a value:

Planning failed. Terraform encountered an error while generating this plan.

╷
│ Error: Error getting client secret
│
│   with provider["registry.terraform.io/deploymenttheory/jamfpro"],
│   on provider.tf line 10, in provider "jamfpro":
│   10: provider "jamfpro" {
│
│ client_secret must be provided either as an environment variable (JAMFPRO_CLIENT_SECRET) or in the Terraform configuration
```

## Expecting Behavior

The value specified in the provider block should be used.
