### PR TITLE
`jamfpro_computer_extension_attribute.data_type`: lower case in state; suppress case differences

### DIFF
--- a/internal/resources/computerextensionattributes/resource.go
+++ b/internal/resources/computerextensionattributes/resource.go
@@ -2,6 +2,7 @@
 package computerextensionattributes
 
 import (
+	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -47,10 +48,16 @@ func ResourceJamfProComputerExtensionAttributes() *schema.Resource {
 				Description: "Description of the computer extension attribute.",
 			},
 			"data_type": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Default:      "String",
-				Description:  "Data type of the computer extension attribute. Can be String / Integer / Date (YYYY-MM-DD hh:mm:ss). Value defaults to `String`.",
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "String",
+				Description: "Data type of the computer extension attribute. Can be String / Integer / Date (YYYY-MM-DD hh:mm:ss). Value defaults to `String`.",
+				StateFunc: func(val any) string {
+					return strings.ToLower(val.(string))
+				},
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return strings.ToLower(old) == strings.ToLower(new)
+				},
 				ValidateFunc: validation.StringInSlice([]string{"string", "integer", "date"}, false),
 			},
 			"input_type": {

--- a/internal/resources/computerextensionattributes/resource.go
+++ b/internal/resources/computerextensionattributes/resource.go
@@ -51,7 +51,7 @@ func ResourceJamfProComputerExtensionAttributes() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Default:     "String",
-				Description: "Data type of the computer extension attribute. Can be String / Integer / Date (YYYY-MM-DD hh:mm:ss). Value defaults to `String`.",
+				Description: "Data type of the computer extension attribute. Can be string / integer / date (YYYY-MM-DD hh:mm:ss). Value defaults to `string`.",
 				StateFunc: func(val any) string {
 					return strings.ToLower(val.(string))
 				},

--- a/internal/resources/computerextensionattributes/resource.go
+++ b/internal/resources/computerextensionattributes/resource.go
@@ -50,11 +50,8 @@ func ResourceJamfProComputerExtensionAttributes() *schema.Resource {
 			"data_type": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Default:     "String",
-				Description: "Data type of the computer extension attribute. Can be string / integer / date (YYYY-MM-DD hh:mm:ss). Value defaults to `string`.",
-				StateFunc: func(val any) string {
-					return strings.ToLower(val.(string))
-				},
+				Default:     "string",
+				Description: "Data type of the computer extension attribute. Can be string / integer / date (YYYY-MM-DD hh:mm:ss). Value defaults to `String`.",
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 					return strings.ToLower(old) == strings.ToLower(new)
 				},

--- a/internal/resources/computerextensionattributes/state.go
+++ b/internal/resources/computerextensionattributes/state.go
@@ -2,6 +2,8 @@
 package computerextensionattributes
 
 import (
+	"strings"
+
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -14,7 +16,7 @@ func updateState(d *schema.ResourceData, resp *jamfpro.ResourceComputerExtension
 	d.Set("name", resp.Name)
 	d.Set("enabled", resp.Enabled)
 	d.Set("description", resp.Description)
-	d.Set("data_type", resp.DataType)
+	d.Set("data_type", strings.ToLower(resp.DataType))
 	d.Set("inventory_display", resp.InventoryDisplay)
 	d.Set("recon_display", resp.ReconDisplay)
 	d.Set("input_type", resp.InputType)


### PR DESCRIPTION
- Added logic to write lower-cased `data_type` to TF state in `extensionattributes.updateState`. 
- I didn't use a `StateFunc` because I couldn't get it to work. It is broken, and has been for 5 years (which raises concern about SDKv2 in general 😟): https://github.com/hashicorp/terraform-plugin-sdk/issues/164. (Or I've held it wrong.)
- Jamf's API does return a capitalized string for data_type - but confirmed one can POST/PUT lower case values.
- Lower cased the values in the attr's default and description.
- Also: added a relevant `SuppressDiffFunc`. Will only impact folks with pre-existing, capitalized values in state. Since the first apply w/ new `updateState` func will rewrite state and so permanently suppress such erroneous diffs, this addition isn't needed. Still good form imo.

`SuppressDiffFunc` hides this for folks with preexisting capitalized values in state:
```hcl
Terraform will perform the following actions:

  # jamfpro_computer_extension_attribute.jamf_patch_java_8_jdk will be updated in-place
  ~ resource "jamfpro_computer_extension_attribute" "jamf_patch_java_8_jdk" {
      ~ data_type         = "Integer" -> "integer"
        id                = "20"
        name              = "jamf-patch-java-8-jdk"
        # (6 unchanged attributes hidden)
    }
```

Confirmed state is updated on apply:

```
✗ grep '"data_type":' terraform.tfstate
            "data_type": "Integer",
            "data_type": "String",
            "data_type": "String",
            "data_type": "Date",
            "data_type": "String",
```
->
```
✗ grep '"data_type":' terraform.tfstate
            "data_type": "integer",
            "data_type": "string",
            "data_type": "string",
            "data_type": "date",
            "data_type": "string",
```