### PR TITLE
Fix the state id type conversion of jamfpro_policy resource

### DIFF
--- a/internal/resources/policies/state_general.go
+++ b/internal/resources/policies/state_general.go
@@ -5,6 +5,7 @@ package policies
 
 import (
 	"reflect"
+	"strconv"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -15,7 +16,7 @@ import (
 func updateState(d *schema.ResourceData, resp *jamfpro.ResourcePolicy) diag.Diagnostics {
 	var diags diag.Diagnostics
 
-	if err := d.Set("id", resp.General.ID); err != nil {
+	if err := d.Set("id", strconv.Itoa(resp.General.ID)); err != nil {
 		diags = append(diags, diag.FromErr(err)...)
 	}
 


### PR DESCRIPTION
## Motivation

State is not registered correctly when `jamfpro_policy`  resource is `apply` or `import`.
I would like to solve this problem.

## Actual Behavior

```sh
$ terraform import jamfpro_policy.sample 123

jamfpro_policy.sample: Importing from ID "123"...
jamfpro_policy.sample: Import prepared!
  Prepared jamfpro_policy for import
jamfpro_policy.sample: Refreshing state... [id=123]
╷
│ Error: id: '' expected type 'string', got unconvertible type 'int', value: '123'
```

## Cause

I believe it is due to the lack of type conversion when storing state (tfstate).