### PR TITLE
Several fixes for plist handling

### DIFF
--- a/internal/resources/common/configurationprofiles/datavalidators/helpers.go
+++ b/internal/resources/common/configurationprofiles/datavalidators/helpers.go
@@ -5,9 +5,9 @@ import (
 	"bytes"
 	"encoding/xml"
 	"fmt"
-	"log"
 	"strings"
 
+	common "github.com/deploymenttheory/terraform-provider-jamfpro/internal/resources/common/configurationprofiles/plist"
 	"howett.net/plist"
 )
 
@@ -30,6 +30,8 @@ func CheckPlistIndentationAndWhiteSpace(plistStr string) error {
 	}
 
 	// Re-encode the plist to check formatting
+	// FIXME: FormatPlist seems to cause keys to be alphabetically sorted (at least in PayloadContent items).
+	//        This causes erroneous plist content mistmatches (line 59). Operators must manually alphabetize.
 	formatted, err := FormatPlist(plistStr)
 	if err != nil {
 		return fmt.Errorf("error formatting plist: %v", err)
@@ -44,14 +46,15 @@ func CheckPlistIndentationAndWhiteSpace(plistStr string) error {
 	formattedLines := strings.Split(normalizedFormatted, "\n")
 
 	if len(origLines) != len(formattedLines) {
-		log.Printf("[DEBUG] Line count mismatch: original has %d lines, formatted has %d lines", len(origLines), len(formattedLines))
-		return fmt.Errorf("plist line count mismatch: source has %d lines, formatted has %d lines, check for trailing lines and whitespace", len(origLines), len(formattedLines))
+		return fmt.Errorf("plist line count mismatch: source has %d lines, formatted has %d lines, check for trailing lines and whitespace. Use `<array>\\n</array>` for empty arrays, not `<array/>`. Same for empty dicts.", len(origLines), len(formattedLines))
 	}
 
 	for i := range origLines {
 		if origLines[i] != formattedLines[i] {
-			log.Printf("[DEBUG] Difference at line %d:\nOriginal: %s\nFormatted: %s\n", i+1, origLines[i], formattedLines[i])
-			return fmt.Errorf("plist is not properly indented at line %d", i+1)
+			if strings.TrimSpace(origLines[i]) == strings.TrimSpace(formattedLines[i]) {
+				return fmt.Errorf("plist is not properly indented or has trailing spaces at line %d. Difference at line %d:\nOriginal: %s\nFormatted: %s", i+1, i+1, origLines[i], formattedLines[i])
+			}
+			return fmt.Errorf("plist content mistmatch at line %d. Try alphabetizing your plist keys (#FIXME). Difference at line %d: Original: %s | Formatted: %s", i+1, i+1, origLines[i], formattedLines[i])
 		}
 	}
 
@@ -60,16 +63,17 @@ func CheckPlistIndentationAndWhiteSpace(plistStr string) error {
 
 // FormatPlist formats the plist structure to a properly indented XML string.
 func FormatPlist(plistStr string) (string, error) {
-	var decoded interface{}
+	var decoded map[string]interface{}
 	_, err := plist.Unmarshal([]byte(plistStr), &decoded)
 	if err != nil {
 		return "", fmt.Errorf("invalid plist: %v", err)
 	}
+	sorted := common.SortPlistKeys(decoded)
 
 	var buf bytes.Buffer
 	encoder := plist.NewEncoder(&buf)
 	encoder.Indent("\t") // Indent with a single tab
-	err = encoder.Encode(decoded)
+	err = encoder.Encode(sorted)
 	if err != nil {
 		return "", err
 	}

--- a/internal/resources/common/configurationprofiles/datavalidators/helpers.go
+++ b/internal/resources/common/configurationprofiles/datavalidators/helpers.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"strings"
 
-	common "github.com/deploymenttheory/terraform-provider-jamfpro/internal/resources/common/configurationprofiles/plist"
+	common "github.com/deploymenttheory/terraform-provider-jamfpro/internal/resources/common/configurationprofiles/plist" // #FIXME This entire file should probably be refactored to better integrate with common/plist.
 	"howett.net/plist"
 )
 

--- a/internal/resources/macosconfigurationprofilesplist/constructor.go
+++ b/internal/resources/macosconfigurationprofilesplist/constructor.go
@@ -18,12 +18,9 @@ func constructJamfProMacOSConfigurationProfilePlist(d *schema.ResourceData) (*ja
 
 	resource = &jamfpro.ResourceMacOSConfigurationProfile{
 		General: jamfpro.MacOSConfigurationProfileSubsetGeneral{
-			Name:               d.Get("name").(string),
-			Description:        d.Get("description").(string),
 			DistributionMethod: d.Get("distribution_method").(string),
 			UserRemovable:      d.Get("user_removable").(bool),
 			Level:              d.Get("level").(string),
-			UUID:               d.Get("uuid").(string),
 			RedeployOnUpdate:   d.Get("redeploy_on_update").(string),
 			Payloads:           html.EscapeString(d.Get("payloads").(string)),
 		},

--- a/internal/resources/macosconfigurationprofilesplist/constructor.go
+++ b/internal/resources/macosconfigurationprofilesplist/constructor.go
@@ -18,9 +18,12 @@ func constructJamfProMacOSConfigurationProfilePlist(d *schema.ResourceData) (*ja
 
 	resource = &jamfpro.ResourceMacOSConfigurationProfile{
 		General: jamfpro.MacOSConfigurationProfileSubsetGeneral{
+			Name:               d.Get("name").(string),
+			Description:        d.Get("description").(string),
 			DistributionMethod: d.Get("distribution_method").(string),
 			UserRemovable:      d.Get("user_removable").(bool),
 			Level:              d.Get("level").(string),
+			UUID:               d.Get("uuid").(string),
 			RedeployOnUpdate:   d.Get("redeploy_on_update").(string),
 			Payloads:           html.EscapeString(d.Get("payloads").(string)),
 		},

--- a/internal/resources/macosconfigurationprofilesplist/diff_suppress.go
+++ b/internal/resources/macosconfigurationprofilesplist/diff_suppress.go
@@ -37,7 +37,7 @@ func DiffSuppressPayloads(k, old, new string, d *schema.ResourceData) bool {
 // processPayload processes the payload by comparing the old and new payloads. It removes specified fields and compares the hashes.
 func processPayload(payload string, source string) (string, error) {
 	log.Printf("Processing %s: %s", source, payload)
-	fieldsToRemove := []string{"PayloadUUID", "PayloadIdentifier", "PayloadOrganization", "PayloadDisplayName"}
+	fieldsToRemove := []string{"PayloadUUID"} // Suppress PayloadUUID differences: Jamf may (always?) sets PayloadContent items' PayloadUUID, ignoring input value.
 	processedPayload, err := plist.ProcessConfigurationProfileForDiffSuppression(payload, fieldsToRemove)
 	if err != nil {
 		return "", err

--- a/internal/resources/macosconfigurationprofilesplist/resource.go
+++ b/internal/resources/macosconfigurationprofilesplist/resource.go
@@ -171,8 +171,8 @@ func ResourceJamfProMacOSConfigurationProfilesPlist() *schema.Resource {
 									},
 									"display_in": {
 										Type:        schema.TypeBool,
-										Description: "Display this profile in this category?",
 										ForceNew:    true,
+										Description: "Display this profile in this category?",
 										Required:    true,
 									},
 									"feature_in": {

--- a/internal/resources/macosconfigurationprofilesplist/resource.go
+++ b/internal/resources/macosconfigurationprofilesplist/resource.go
@@ -33,7 +33,7 @@ func ResourceJamfProMacOSConfigurationProfilesPlist() *schema.Resource {
 				Computed:    true,
 				Description: "The unique identifier of the macOS configuration profile.",
 			},
-			"display_name": {
+			"name": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Jamf UI name for configuration profile. Conforms to top-level PayloadDisplayName in payloads attribute's plist string. Modify there.",

--- a/internal/resources/macosconfigurationprofilesplist/resource.go
+++ b/internal/resources/macosconfigurationprofilesplist/resource.go
@@ -2,7 +2,6 @@
 package macosconfigurationprofilesplist
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/deploymenttheory/terraform-provider-jamfpro/internal/resources/common/configurationprofiles/plist"
@@ -29,7 +28,6 @@ func ResourceJamfProMacOSConfigurationProfilesPlist() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 		Schema: map[string]*schema.Schema{
-
 			"id": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -37,18 +35,18 @@ func ResourceJamfProMacOSConfigurationProfilesPlist() *schema.Resource {
 			},
 			"name": {
 				Type:        schema.TypeString,
-				Required:    true,
-				Description: "Jamf UI name for configuration profile.",
+				Computed:    true,
+				Description: "Jamf UI name for configuration profile. Conforms to top-level PayloadDisplayName in payloads attribute's plist string. Modify there.",
 			},
 			"description": {
 				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "Description of the configuration profile.",
+				Computed:    true,
+				Description: "Description of the configuration profile. Conforms to top-level PayloadDescription in payloads attribute's plist string. Modify there.",
 			},
 			"uuid": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "The universally unique identifier for the profile.",
+				Description: "The universally unique identifier for the profile. Conforms to top-level PayloadIdentifier in payloads attribute's plist string. Modify there.",
 			},
 			"site_id":     sharedschemas.GetSharedSchemaSite(),
 			"category_id": sharedschemas.GetSharedSchemaCategory(),
@@ -81,18 +79,11 @@ func ResourceJamfProMacOSConfigurationProfilesPlist() *schema.Resource {
 				Description:      "A MacOS configuration profile as a plist-formatted XML string.",
 			},
 			"redeploy_on_update": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Default:     "Newly Assigned", // This is always "Newly Assigned" on existing profile objects, but may be set "All" on profile update requests and in TF state.
-				Description: "Defines the redeployment behaviour when a mobile device config profile update occurs.This is always 'Newly Assigned' on new profile objects, but may be set 'All' on profile update requests and in TF state",
-				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
-					v := val.(string)
-					if v == "All" || v == "Newly Assigned" {
-						return
-					}
-					errs = append(errs, fmt.Errorf("%q must be either 'All' or 'Newly Assigned', got: %s", key, v))
-					return warns, errs
-				},
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      "Newly Assigned", // This is always "Newly Assigned" on existing profile objects, but may be set "All" on profile update requests and in TF state.
+				Description:  "Defines the redeployment behaviour when a mobile device config profile update occurs.This is always 'Newly Assigned' on new profile objects, but may be set 'All' on profile update requests and in TF state",
+				ValidateFunc: validation.StringInSlice([]string{"All", "Newly Assigned"}, false),
 			},
 			"scope": {
 				Type:        schema.TypeList,
@@ -180,14 +171,12 @@ func ResourceJamfProMacOSConfigurationProfilesPlist() *schema.Resource {
 									},
 									"display_in": {
 										Type:        schema.TypeBool,
-										ForceNew:    true,
 										Description: "Display this profile in this category?",
 										Required:    true,
 									},
 									"feature_in": {
 										Type:        schema.TypeBool,
 										Description: "Feature this profile in this category?",
-										ForceNew:    true,
 										Required:    true,
 									},
 								},

--- a/internal/resources/macosconfigurationprofilesplist/resource.go
+++ b/internal/resources/macosconfigurationprofilesplist/resource.go
@@ -172,11 +172,13 @@ func ResourceJamfProMacOSConfigurationProfilesPlist() *schema.Resource {
 									"display_in": {
 										Type:        schema.TypeBool,
 										Description: "Display this profile in this category?",
+										ForceNew:    true,
 										Required:    true,
 									},
 									"feature_in": {
 										Type:        schema.TypeBool,
 										Description: "Feature this profile in this category?",
+										ForceNew:    true,
 										Required:    true,
 									},
 								},

--- a/internal/resources/macosconfigurationprofilesplist/resource.go
+++ b/internal/resources/macosconfigurationprofilesplist/resource.go
@@ -33,7 +33,7 @@ func ResourceJamfProMacOSConfigurationProfilesPlist() *schema.Resource {
 				Computed:    true,
 				Description: "The unique identifier of the macOS configuration profile.",
 			},
-			"name": {
+			"display_name": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Jamf UI name for configuration profile. Conforms to top-level PayloadDisplayName in payloads attribute's plist string. Modify there.",


### PR DESCRIPTION
- Improved `CheckPlistIndentationAndWhiteSpace` / `FormatPlist`
  - Removed debug log output which simply restates the error output
  - Improved error output for line count mismatches with hints for the most common causes (the format of empty arrays and dicts 🤦)
  - Added unique errors for content mismatches due to indentation/whitespace and those due to actual content mismatches.
  - Added logic to sort the keys in the formatted comparison plist. The unformatted plist does have sorted keys, 

- Added missing `eq=` validation implementation
  - Currently `eq=` is defined but unused in validation
  - This is min viable implementation. It only works for string values b/c of mapstructure limitations
  - Removed the one integer eq=, for `PayloadVersion`
  - Changed `oneof=` validation to `eq=<valid string one>=<valid string two>` etc. Easiest to implement. Just making up DSLs over here.

As it now says on the tin, `jamfpro_macos_configuration_profile_plist` is geared towards plist input. I've therefore made three changes which preference the plist-defined value of an attribute over the resource-defined value. The latter is made computed if not already. 

For each of these values, Jamf's server side processing insists on conforming the plist value and the metadata attribute value - we must either compute the attribute or suppress the plist key diff. Computing the attribute produces less surprising outcomes/output. 

- Made `jamfpro_macos_configuration_profile_plist.description` a computed attribute. One can only _sometimes_ set this value safely over the API. With a specific, valid `PayloadContent` structure (one with nested `PayloadContent` dicts), setting description can cause Jamf to truncate the profile's entire `PayloadContent` array. This irreversibly breaks the profile: the Jamf server throws an error on every subsequent access attempt.
  - See: #351 
  - [Questionably wise] Added logic which injects a top-level `PayloadDescription` into parsed input plist, where none exists. The set value follows a reverse-engineered understanding of Jamf's computed default `PayloadDescription` value.
  - Stopped suppressing diffs in `PayloadDescription`. Operators are now expected (per `description` attribute's help text) to use this plist value to manage both actual profile's description and the Jamf profile object's description (which then becomes the computed attribute).

- Made `jamfpro_macos_configuration_profile_plist.name` a computed attribute. `name` is to `PayloadDisplayName` as `description` is to `PayloadDescription` (except in my testing changing name doesn't delete payload content).
  - Stopped suppressing diffs in `PayloadDisplayName`.

- Stopped suppressing diffs in `PayloadIdentifier`. `uuid` is to `PayloadIdentifier` as `description` is to `PayloadDescription` (except in my testing changing doesn't delete payload content). 
  - `uuid` is already a computed attribute.
  - Continued suppressing diffs in `PayloadUUID`. The top-level value can be changed, it seems - but payload items in `PayloadContent` seems to have their `PayloadUUID` generated by Jamf's server-side processing automatically (maybe not in all cases?). We want to suppress that drift, though it means erroneous suppression of plans which only change top-level `PayloadUUID`.