### PR TITLE
Fix a scope validation for policy

### DIFF
--- a/internal/resources/policies/constructor.go
+++ b/internal/resources/policies/constructor.go
@@ -247,7 +247,7 @@ func constructScope(d *schema.ResourceData, resource *jamfpro.ResourcePolicy) er
 	}
 
 	// TODO make this better, it works for now
-	if resource.Scope.AllComputers && (resource.Scope.Computers != nil ||
+	if !resource.Scope.AllComputers && (resource.Scope.Computers != nil ||
 		resource.Scope.ComputerGroups != nil ||
 		resource.Scope.Departments != nil ||
 		resource.Scope.Buildings != nil) {


### PR DESCRIPTION
In the scope of policy, if we are specifying all computers, then policy does not need any other scope.
Therefore, I have changed the validation logic to work as expected.