### PR TITLE
Added profile plist validate flag

### DIFF
--- a/docs/resources/macos_configuration_profile_plist.md
+++ b/docs/resources/macos_configuration_profile_plist.md
@@ -22,6 +22,7 @@ resource "jamfpro_macos_configuration_profile_plist" "jamfpro_macos_configuratio
   level               = "User"                           // "User", "Device"
   distribution_method = "Make Available in Self Service" // "Make Available in Self Service", "Install Automatically"
   payloads            = file("${path.module}/path/to/your/file.mobileconfig")
+  payloadvalidate     = true
   user_removable      = false
 
   // Optional Block
@@ -152,6 +153,7 @@ resource "jamfpro_macos_configuration_profile" "jamfpro_macos_configuration_prof
 - `description` (String) Description of the configuration profile.
 - `distribution_method` (String) The distribution method for the configuration profile. ['Make Available in Self Service','Install Automatically']
 - `level` (String) The deployment level of the configuration profile. Available options are: 'User' or 'System'. Note: 'System' is mapped to 'Computer Level' in the Jamf Pro GUI.
+- `payloadvalidate` (Boolean) Validate payload XML. Turn off for computed values or forcing badly-formed XML to config
 - `redeploy_on_update` (String) Defines the redeployment behaviour when a mobile device config profile update occurs.This is always 'Newly Assigned' on new profile objects, but may be set 'All' on profile update requests and in TF state
 - `self_service` (Block List, Max: 1) Self Service Configuration (see [below for nested schema](#nestedblock--self_service))
 - `site_id` (Number) Jamf Pro Site-related settings of the policy.

--- a/examples/resources/jamfpro_macos_configuration_profile_plist/resource.tf
+++ b/examples/resources/jamfpro_macos_configuration_profile_plist/resource.tf
@@ -11,6 +11,7 @@ resource "jamfpro_macos_configuration_profile_plist" "jamfpro_macos_configuratio
   level               = "User"                           // "User", "Device"
   distribution_method = "Make Available in Self Service" // "Make Available in Self Service", "Install Automatically"
   payloads            = file("${path.module}/path/to/your/file.mobileconfig")
+  payloadvalidate     = true
   user_removable      = false
 
   // Optional Block

--- a/internal/resources/macosconfigurationprofilesplist/data_validator.go
+++ b/internal/resources/macosconfigurationprofilesplist/data_validator.go
@@ -12,18 +12,30 @@ import (
 
 // mainCustomDiffFunc orchestrates all custom diff validations.
 func mainCustomDiffFunc(ctx context.Context, diff *schema.ResourceDiff, i interface{}) error {
-	if err := validateDistributionMethod(ctx, diff, i); err != nil {
-		return err
+	if diff.Get("payloadvalidate").(bool) {
+		if err := normalizePayloadState(ctx, diff, i); err != nil {
+			return err
+		}
+
+		if err := validateDistributionMethod(ctx, diff, i); err != nil {
+			return err
+		}
+
+		if err := validateMacOSConfigurationProfileLevel(ctx, diff, i); err != nil {
+			return err
+		}
+
+		if err := validateConfigurationProfileFormatting(ctx, diff, i); err != nil {
+			return err
+		}
+
 	}
 
-	if err := validateMacOSConfigurationProfileLevel(ctx, diff, i); err != nil {
-		return err
-	}
+	return nil
+}
 
-	if err := validateConfigurationProfileFormatting(ctx, diff, i); err != nil {
-		return err
-	}
-
+func normalizePayloadState(_ context.Context, diff *schema.ResourceDiff, _ interface{}) error {
+	diff.SetNew("payloads", plist.NormalizePayloadState(diff.Get("payloads").(string)))
 	return nil
 }
 

--- a/internal/resources/macosconfigurationprofilesplist/diff_suppress.go
+++ b/internal/resources/macosconfigurationprofilesplist/diff_suppress.go
@@ -11,27 +11,33 @@ import (
 
 // DiffSuppressPayloads is a custom diff suppression function for the payloads attribute.
 func DiffSuppressPayloads(k, old, new string, d *schema.ResourceData) bool {
-	log.Printf("Suppressing diff for key: %s", k)
 
-	processedOldPayload, err := processPayload(old, "Terraform state payload")
-	if err != nil {
-		log.Printf("Error processing old payload (Terraform state): %v", err)
-		return false
+	if d.Get("payloadvalidate").(bool) {
+		log.Printf("Suppressing diff for key: %s", k)
+
+		processedOldPayload, err := processPayload(old, "Terraform state payload")
+		if err != nil {
+			log.Printf("Error processing old payload (Terraform state): %v", err)
+			return false
+		}
+
+		processedNewPayload, err := processPayload(new, "Jamf Pro server payload")
+		if err != nil {
+			log.Printf("Error processing new payload (Jamf Pro server): %v", err)
+			return false
+		}
+
+		oldHash := common.HashString(processedOldPayload)
+		newHash := common.HashString(processedNewPayload)
+
+		log.Printf("Old payload hash (Terraform state): %s\nOld payload (processed): %s", oldHash, processedOldPayload)
+		log.Printf("New payload hash (Jamf Pro server): %s\nNew payload (processed): %s", newHash, processedNewPayload)
+
+		return oldHash == newHash
+	} else {
+		return false //retain any drift on format (as we are not validating in this block)
 	}
 
-	processedNewPayload, err := processPayload(new, "Jamf Pro server payload")
-	if err != nil {
-		log.Printf("Error processing new payload (Jamf Pro server): %v", err)
-		return false
-	}
-
-	oldHash := common.HashString(processedOldPayload)
-	newHash := common.HashString(processedNewPayload)
-
-	log.Printf("Old payload hash (Terraform state): %s\nOld payload (processed): %s", oldHash, processedOldPayload)
-	log.Printf("New payload hash (Jamf Pro server): %s\nNew payload (processed): %s", newHash, processedNewPayload)
-
-	return oldHash == newHash
 }
 
 // processPayload processes the payload by comparing the old and new payloads. It removes specified fields and compares the hashes.

--- a/internal/resources/macosconfigurationprofilesplist/resource.go
+++ b/internal/resources/macosconfigurationprofilesplist/resource.go
@@ -75,10 +75,16 @@ func ResourceJamfProMacOSConfigurationProfilesPlist() *schema.Resource {
 			"payloads": {
 				Type:             schema.TypeString,
 				Required:         true,
-				StateFunc:        plist.NormalizePayloadState,
+				StateFunc:        nil, //set by CustomizeDiff logic
 				ValidateFunc:     plist.ValidatePayload,
 				DiffSuppressFunc: DiffSuppressPayloads,
 				Description:      "A MacOS configuration profile as a plist-formatted XML string.",
+			},
+			"payloadvalidate": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: "Validate payload XML. Turn off for computed values or forcing badly-formed XML to config",
 			},
 			"redeploy_on_update": {
 				Type:        schema.TypeString,


### PR DESCRIPTION
Per Hashicorp

> NOTE: CustomizeDiff does not currently support computed/"known after apply" values from other resource attributes.

This makes it impossible to use computed or otherwise gleaned plists (e.g. from dynamically created resources).

Adding a resource flag to suppress validation and format checks . Flag is optional and defaults to "true" so will not change existing functionality.

Had to moved StateFunc inside of the existing `CustomizeDiff (mainCustomDiffFunc)` with an embedded func of `normalizePayloadState`

Kept new functionality only to MacOS profiles, but no reason it cannot be included on Mobile too