### PR TITLE
Bugfix macOS config profiles - numerous bug fixes for stating, forcenew and diff suppression

### DIFF
--- a/examples/resources/jamfpro_macos_configuration_profile_plist/resource.tf
+++ b/examples/resources/jamfpro_macos_configuration_profile_plist/resource.tf
@@ -4,6 +4,24 @@ variable "version_number" {
   default     = "v1.0"
 }
 
+// Minimum viable example of creating a macOS configuration profile in Jamf Pro for automatic installation using a plist source file
+
+resource "jamfpro_macos_configuration_profile_plist" "jamfpro_macos_configuration_profile_064" {
+  name                = "your-name-${var.version_number}"
+  description         = "An example mobile device configuration profile."
+  level               = "System"
+  distribution_method = "Install Automatically" // "Make Available in Self Service", "Install Automatically"
+  payloads            = file("${path.module}/path/to/your/file.mobileconfig")
+  payload_validate    = true
+  user_removable      = false
+
+  scope {
+    all_computers = true
+    all_jss_users = false
+  }
+
+}
+
 // Example of creating a macOS configuration profile in Jamf Pro for self service using a plist source file
 resource "jamfpro_macos_configuration_profile_plist" "jamfpro_macos_configuration_profile_001" {
   name                = "your-name-${var.version_number}"
@@ -11,7 +29,7 @@ resource "jamfpro_macos_configuration_profile_plist" "jamfpro_macos_configuratio
   level               = "User"                           // "User", "Device"
   distribution_method = "Make Available in Self Service" // "Make Available in Self Service", "Install Automatically"
   payloads            = file("${path.module}/path/to/your/file.mobileconfig")
-  payloadvalidate     = true
+  payload_validate     = true
   user_removable      = false
 
   // Optional Block
@@ -20,8 +38,6 @@ resource "jamfpro_macos_configuration_profile_plist" "jamfpro_macos_configuratio
 
   // Optional Block
   category_id = 5
-
-  // Optional Block
   scope {
     all_computers = false
     all_jss_users = false
@@ -33,6 +49,7 @@ resource "jamfpro_macos_configuration_profile_plist" "jamfpro_macos_configuratio
     jss_user_ids       = sort([2, 1])
     jss_user_group_ids = [4, 505]
 
+    // Optional Block
     limitations {
       network_segment_ids                  = [4, 5]
       ibeacon_ids                          = [3, 4]
@@ -40,6 +57,7 @@ resource "jamfpro_macos_configuration_profile_plist" "jamfpro_macos_configuratio
       directory_service_usergroup_ids      = [3, 4]
     }
 
+    // Optional Block
     exclusions {
       computer_ids                         = [16, 20, 21]
       computer_group_ids                   = sort([78, 1])
@@ -85,14 +103,13 @@ resource "jamfpro_macos_configuration_profile" "jamfpro_macos_configuration_prof
   distribution_method = "Install Automatically" // "Make Available in Self Service", "Install Automatically"
   payloads            = file("${path.module}/path/to/your/file.mobileconfig")
   user_removable      = false
+  payload_validate     = true
 
   // Optional Block
   site_id = 1
 
   // Optional Block
   category_id = 1
-
-  // Optional Block
   scope {
     all_computers = false
     all_jss_users = false
@@ -104,13 +121,14 @@ resource "jamfpro_macos_configuration_profile" "jamfpro_macos_configuration_prof
     jss_user_ids       = sort([2, 1])
     jss_user_group_ids = [4, 505]
 
+    // Optional Block
     limitations {
       network_segment_ids                  = [4, 5]
       ibeacon_ids                          = [3, 4]
       directory_service_or_local_usernames = ["Jane Smith", "John Doe"]
       directory_service_usergroup_ids      = [3, 4]
     }
-
+    // Optional Block
     exclusions {
       computer_ids                         = [16, 20, 21]
       computer_group_ids                   = sort([78, 1])

--- a/internal/resources/common/configurationprofiles/plist/diffsuppression.go
+++ b/internal/resources/common/configurationprofiles/plist/diffsuppression.go
@@ -108,10 +108,11 @@ func trimTrailingWhitespace(plist string) string {
 }
 
 // normalizeXMLInPlist recursively normalizes XML content within a plist structure
+// and unescapes HTML entities in string values to ensure consistent comparison.
 func normalizeXMLInPlist(data interface{}) interface{} {
 	switch v := data.(type) {
 	case string:
-		return normalizeXMLContent(v)
+		return html.UnescapeString(v)
 	case map[string]interface{}:
 		for key, value := range v {
 			v[key] = normalizeXMLInPlist(value)
@@ -122,23 +123,4 @@ func normalizeXMLInPlist(data interface{}) interface{} {
 		}
 	}
 	return data
-}
-
-// normalizeXMLContent decodes XML entities and normalizes special characters
-func normalizeXMLContent(content string) string {
-	// Decode HTML entities
-	decoded := html.UnescapeString(content)
-
-	// Replace XML entities with their actual characters
-	replacer := strings.NewReplacer(
-		"&quot;", "\"",
-		"&#34;", "\"",
-		"&amp;", "&",
-		"&lt;", "<",
-		"&gt;", ">",
-		"&#39;", "'",
-	)
-	normalized := replacer.Replace(decoded)
-
-	return normalized
 }

--- a/internal/resources/macosconfigurationprofilesplist/constructor.go
+++ b/internal/resources/macosconfigurationprofilesplist/constructor.go
@@ -84,8 +84,10 @@ func constructMacOSConfigurationProfileSubsetScope(data map[string]interface{}) 
 	}
 
 	if exclusions, ok := data["exclusions"]; ok && len(exclusions.([]interface{})) > 0 {
-		exclusionData := exclusions.([]interface{})[0].(map[string]interface{})
-		scope.Exclusions = constructExclusions(exclusionData)
+		exclusionData := exclusions.([]interface{})[0]
+		if exclusionMap, ok := exclusionData.(map[string]interface{}); ok {
+			scope.Exclusions = constructExclusions(exclusionMap)
+		}
 	}
 
 	return scope
@@ -115,28 +117,28 @@ func constructLimitations(data map[string]interface{}) jamfpro.MacOSConfiguratio
 func constructExclusions(data map[string]interface{}) jamfpro.MacOSConfigurationProfileSubsetExclusions {
 	exclusions := jamfpro.MacOSConfigurationProfileSubsetExclusions{}
 
-	if computerIDs, ok := data["computer_ids"]; ok {
+	if computerIDs, ok := data["computer_ids"]; ok && len(computerIDs.([]interface{})) > 0 {
 		exclusions.Computers = constructComputers(computerIDs.([]interface{}))
 	}
-	if computerGroupIDs, ok := data["computer_group_ids"]; ok {
+	if computerGroupIDs, ok := data["computer_group_ids"]; ok && len(computerGroupIDs.([]interface{})) > 0 {
 		exclusions.ComputerGroups = constructScopeEntitiesFromIds(computerGroupIDs.([]interface{}))
 	}
-	if userIDs, ok := data["jss_user_ids"]; ok {
+	if userIDs, ok := data["jss_user_ids"]; ok && len(userIDs.([]interface{})) > 0 {
 		exclusions.JSSUsers = constructScopeEntitiesFromIds(userIDs.([]interface{}))
 	}
-	if userGroupIDs, ok := data["jss_user_group_ids"]; ok {
+	if userGroupIDs, ok := data["jss_user_group_ids"]; ok && len(userGroupIDs.([]interface{})) > 0 {
 		exclusions.JSSUserGroups = constructScopeEntitiesFromIds(userGroupIDs.([]interface{}))
 	}
-	if buildingIDs, ok := data["building_ids"]; ok {
+	if buildingIDs, ok := data["building_ids"]; ok && len(buildingIDs.([]interface{})) > 0 {
 		exclusions.Buildings = constructScopeEntitiesFromIds(buildingIDs.([]interface{}))
 	}
-	if departmentIDs, ok := data["department_ids"]; ok {
+	if departmentIDs, ok := data["department_ids"]; ok && len(departmentIDs.([]interface{})) > 0 {
 		exclusions.Departments = constructScopeEntitiesFromIds(departmentIDs.([]interface{}))
 	}
-	if networkSegmentIDs, ok := data["network_segment_ids"]; ok {
+	if networkSegmentIDs, ok := data["network_segment_ids"]; ok && len(networkSegmentIDs.([]interface{})) > 0 {
 		exclusions.NetworkSegments = constructNetworkSegments(networkSegmentIDs.([]interface{}))
 	}
-	if ibeaconIDs, ok := data["ibeacon_ids"]; ok {
+	if ibeaconIDs, ok := data["ibeacon_ids"]; ok && len(ibeaconIDs.([]interface{})) > 0 {
 		exclusions.IBeacons = constructScopeEntitiesFromIds(ibeaconIDs.([]interface{}))
 	}
 

--- a/internal/resources/macosconfigurationprofilesplist/resource.go
+++ b/internal/resources/macosconfigurationprofilesplist/resource.go
@@ -163,13 +163,13 @@ func ResourceJamfProMacOSConfigurationProfilesPlist() *schema.Resource {
 								Schema: map[string]*schema.Schema{
 									"id": {
 										Type:        schema.TypeInt,
-										Description: "ID of category",
-										Optional:    true,
+										Description: "ID of category. Request requires both the ID and name to be set.",
+										Required:    true,
 									},
 									"name": {
 										Type:        schema.TypeString,
-										Description: "Name of category",
-										Optional:    true,
+										Description: "Name of category. Request requires both the ID and name to be set.",
+										Required:    true,
 									},
 									"display_in": {
 										Type:        schema.TypeBool,

--- a/internal/resources/macosconfigurationprofilesplist/resource.go
+++ b/internal/resources/macosconfigurationprofilesplist/resource.go
@@ -85,7 +85,16 @@ func ResourceJamfProMacOSConfigurationProfilesPlist() *schema.Resource {
 			"redeploy_on_update": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "Defines the redeployment behaviour when a macOS config profile update occurs.This is always 'Newly Assigned' on new profile objects,pre jamf pro 11.7 it was possible be set behaviour to 'All' on profile update requests.",
+				Default:     "Newly Assigned", // This is always "Newly Assigned" on existing profile objects, but may be set "All" on profile update requests and in TF state.
+				Description: "Defines the redeployment behaviour when a mobile device config profile update occurs.This is always 'Newly Assigned' on new profile objects, but may be set 'All' on profile update requests and in TF state",
+				// ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
+				// 	v := val.(string)
+				// 	if v == "All" || v == "Newly Assigned" {
+				// 		return
+				// 	}
+				// 	errs = append(errs, fmt.Errorf("%q must be either 'All' or 'Newly Assigned', got: %s", key, v))
+				// 	return warns, errs
+				// },
 			},
 			"scope": {
 				Type:        schema.TypeList,
@@ -106,13 +115,11 @@ func ResourceJamfProMacOSConfigurationProfilesPlist() *schema.Resource {
 							Type:        schema.TypeString,
 							Optional:    true,
 							Description: "Text shown on Self Service install button",
-							Default:     "Install",
 						},
 						"self_service_description": {
 							Type:        schema.TypeString,
 							Optional:    true,
 							Description: "Description shown in Self Service",
-							Default:     nil,
 						},
 						"force_users_to_view_description": {
 							Type:        schema.TypeBool,
@@ -132,13 +139,11 @@ func ResourceJamfProMacOSConfigurationProfilesPlist() *schema.Resource {
 						"notification_subject": {
 							Type:        schema.TypeString,
 							Optional:    true,
-							Default:     "no message subject set",
 							Description: "Message Subject",
 						},
 						"notification_message": {
 							Type:        schema.TypeString,
 							Optional:    true,
-							Default:     "",
 							Description: "Message body",
 						},
 						// "self_service_icon": {
@@ -163,24 +168,22 @@ func ResourceJamfProMacOSConfigurationProfilesPlist() *schema.Resource {
 								Schema: map[string]*schema.Schema{
 									"id": {
 										Type:        schema.TypeInt,
-										Description: "ID of category. Request requires both the ID and name to be set.",
+										Description: "ID of category. Both ID and Name are required",
 										Required:    true,
 									},
 									"name": {
 										Type:        schema.TypeString,
-										Description: "Name of category. Request requires both the ID and name to be set.",
+										Description: "Name of category. Both ID and Name are required",
 										Required:    true,
 									},
 									"display_in": {
 										Type:        schema.TypeBool,
-										ForceNew:    true,
 										Description: "Display this profile in this category?",
 										Required:    true,
 									},
 									"feature_in": {
 										Type:        schema.TypeBool,
 										Description: "Feature this profile in this category?",
-										ForceNew:    true,
 										Required:    true,
 									},
 								},

--- a/internal/resources/macosconfigurationprofilesplist/resource.go
+++ b/internal/resources/macosconfigurationprofilesplist/resource.go
@@ -2,7 +2,6 @@
 package macosconfigurationprofilesplist
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/deploymenttheory/terraform-provider-jamfpro/internal/resources/common/sharedschemas"
@@ -85,17 +84,8 @@ func ResourceJamfProMacOSConfigurationProfilesPlist() *schema.Resource {
 			},
 			"redeploy_on_update": {
 				Type:        schema.TypeString,
-				Optional:    true,
-				Default:     "Newly Assigned", // This is always "Newly Assigned" on existing profile objects, but may be set "All" on profile update requests and in TF state.
-				Description: "Defines the redeployment behaviour when a mobile device config profile update occurs.This is always 'Newly Assigned' on new profile objects, but may be set 'All' on profile update requests and in TF state",
-				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
-					v := val.(string)
-					if v == "All" || v == "Newly Assigned" {
-						return
-					}
-					errs = append(errs, fmt.Errorf("%q must be either 'All' or 'Newly Assigned', got: %s", key, v))
-					return warns, errs
-				},
+				Computed:    true,
+				Description: "Defines the redeployment behaviour when a macOS config profile update occurs.This is always 'Newly Assigned' on new profile objects,pre jamf pro 11.7 it was possible be set behaviour to 'All' on profile update requests.",
 			},
 			"scope": {
 				Type:        schema.TypeList,

--- a/internal/resources/macosconfigurationprofilesplist/state.go
+++ b/internal/resources/macosconfigurationprofilesplist/state.go
@@ -49,7 +49,7 @@ func updateState(d *schema.ResourceData, resp *jamfpro.ResourceMacOSConfiguratio
 	}
 
 	defaultSelfService := jamfpro.MacOSConfigurationProfileSubsetSelfService{}
-	if !compareSelfService(resp.SelfService, defaultSelfService) {
+	if !reflect.DeepEqual(resp.SelfService, defaultSelfService) {
 		if selfServiceData, err := setSelfService(resp.SelfService); err != nil {
 			diags = append(diags, diag.FromErr(err)...)
 		} else if selfServiceData != nil {
@@ -311,20 +311,6 @@ func setSelfService(selfService jamfpro.MacOSConfigurationProfileSubsetSelfServi
 	log.Printf("Final state self service: %+v\n", selfServiceBlock)
 
 	return selfServiceBlock, nil
-}
-
-// TODO what is going on here?
-// compareSelfService compares two MacOSConfigurationProfileSubsetSelfService structs
-func compareSelfService(a, b jamfpro.MacOSConfigurationProfileSubsetSelfService) bool {
-	return a.InstallButtonText == b.InstallButtonText &&
-		a.SelfServiceDescription == b.SelfServiceDescription &&
-		a.ForceUsersToViewDescription == b.ForceUsersToViewDescription &&
-		reflect.DeepEqual(a.SelfServiceIcon, b.SelfServiceIcon) &&
-		a.FeatureOnMainPage == b.FeatureOnMainPage &&
-		reflect.DeepEqual(a.SelfServiceCategories, b.SelfServiceCategories) &&
-		a.Notification == b.Notification &&
-		a.NotificationSubject == b.NotificationSubject &&
-		a.NotificationMessage == b.NotificationMessage
 }
 
 // helper functions

--- a/internal/resources/macosconfigurationprofilesplist/state.go
+++ b/internal/resources/macosconfigurationprofilesplist/state.go
@@ -49,7 +49,8 @@ func updateState(d *schema.ResourceData, resp *jamfpro.ResourceMacOSConfiguratio
 	}
 
 	defaultSelfService := jamfpro.MacOSConfigurationProfileSubsetSelfService{}
-	if !reflect.DeepEqual(resp.SelfService, defaultSelfService) {
+	removeSelfService := reflect.DeepEqual(resp.SelfService, defaultSelfService) || resp.General.DistributionMethod == "Install Automatically"
+	if !removeSelfService {
 		if selfServiceData, err := setSelfService(resp.SelfService); err != nil {
 			diags = append(diags, diag.FromErr(err)...)
 		} else if selfServiceData != nil {
@@ -58,6 +59,7 @@ func updateState(d *schema.ResourceData, resp *jamfpro.ResourceMacOSConfiguratio
 			}
 		}
 	} else {
+		log.Println("Self-service block is empty, default, or set to 'Install Automatically', removing from state")
 		if err := d.Set("self_service", []interface{}{}); err != nil {
 			diags = append(diags, diag.FromErr(err)...)
 		}


### PR DESCRIPTION
+ fix for state when adding or removing the the self service block
+ removal of the ForceNew field to stop the redeployment of a config profile when a self service category is added or removed
+ simplified / improved diff suppression for returned html responses for plists
+ removed unnecessary default values for self service