### PR TITLE
[DNM (before settings changes)] auto version bumping & suggested repo settings changes

### DIFF
--- a/.github/workflows/code-check-and-tests.yaml
+++ b/.github/workflows/code-check-and-tests.yaml
@@ -63,7 +63,6 @@ jobs:
           cache: true
       - run: go vet ./...
   lint:
-    name: golangcli-lint
     needs: [build]
     runs-on: ubuntu-20.04
     steps:
@@ -77,6 +76,11 @@ jobs:
         with:
           args: --timeout=5m --config=/my/path/.golangci.yml
           version: v1.58
+      - name: yamllint
+        run: |
+          sudo apt-get install -y yamllint
+          yamllint --version
+          yamllint .
   generate:
     name: go generate
     needs: [build]

--- a/.github/workflows/code-check-and-tests.yaml
+++ b/.github/workflows/code-check-and-tests.yaml
@@ -78,8 +78,6 @@ jobs:
           version: v1.58
       - name: yamllint
         run: |
-          sudo apt-get install -y yamllint
-          yamllint --version
           yamllint .
   generate:
     name: go generate

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -39,38 +39,38 @@ jobs:
         # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
-      with:
-        languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
 
-        # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        # queries: security-extended,security-and-quality
+          # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+          # queries: security-extended,security-and-quality
 
 
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
+      # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
+      # If this step fails, then you should remove it and run the build manually (see below)
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
 
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+      # ℹ️ Command-line programs to run using the OS shell.
+      # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
 
-    #   If the Autobuild fails above, remove it and uncomment the following three lines.
-    #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
+      #   If the Autobuild fails above, remove it and uncomment the following three lines.
+      #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
 
-    # - run: |
-    #     echo "Run, Build Application using script"
-    #     ./location_of_script_within_repo/buildscript.sh
+      # - run: |
+      #     echo "Run, Build Application using script"
+      #     ./location_of_script_within_repo/buildscript.sh
 
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
-      with:
-        category: "/language:${{matrix.language}}"
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{matrix.language}}"

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -6,16 +6,16 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Source
-      uses: actions/checkout@v4.1.1
-    - name: Render terraform docs and push changes back to PR
-      uses: terraform-docs/gh-actions@main
-      with:
-        working-dir: examples/
-        git-push: "true"
-        output-format: markdown document
-        output-file: USAGE.md
-        output-method: replace
-        args: --sensitive=false --hide requirements --required=false
-        indention: 3
-        config-file: .terraform-docs.yml
+      - name: Checkout Source
+        uses: actions/checkout@v4.1.1
+      - name: Render terraform docs and push changes back to PR
+        uses: terraform-docs/gh-actions@main
+        with:
+          working-dir: examples/
+          git-push: "true"
+          output-format: markdown document
+          output-file: USAGE.md
+          output-method: replace
+          args: --sensitive=false --hide requirements --required=false
+          indention: 3
+          config-file: .terraform-docs.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,9 +9,14 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_run:
     branches:
       - main
       - release
+    workflows:
+      - 'Tests'
+    types:
+      - completed
 
 jobs:
   # bump the version if not manually tagged

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ on:
       - 'v*'
     branches:
       - main
+      - development
 
 jobs:
   # bump the version if not manually tagged
@@ -25,13 +26,14 @@ jobs:
       default_bump: patch
       default_prerelease_bump: prepatch
       github_token: ${{ github.token }}
-      pre_release_branches: .*
+      pre_release_branches: development
       release_branches: main
       tag_prefix: v
+      custom_release_rules: 'fix:patch,bug:patch,bugfix:patch,patch:patch,feat:patch,feat:minor:new resource,minor:minor,feat:major:breaking change,feat:major:API change,major:major'
 
   # Release for Partner and Community Providers
   terraform-provider-release:
-    environment: 'Hashicorp Registry'
+    environment: 'terraform registry'
     name: 'Terraform Provider Release'
     uses: hashicorp/ghaction-terraform-provider-release/.github/workflows/community.yml@v5.0.0
     secrets:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ on:
       - 'v*'
     branches:
       - main
-      - development
+      - release
 
 jobs:
   # bump the version if not manually tagged
@@ -26,8 +26,8 @@ jobs:
       default_bump: patch
       default_prerelease_bump: prepatch
       github_token: ${{ github.token }}
-      pre_release_branches: development
-      release_branches: main
+      pre_release_branches: main
+      release_branches: release
       tag_prefix: v
       custom_release_rules: 'fix:patch,bug:patch,bugfix:patch,patch:patch,feat:patch,feat:minor:new resource,minor:minor,feat:major:breaking change,feat:major:API change,major:major'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,13 +4,34 @@ name: Terraform Provider Release
 # This GitHub action creates a release when a tag that matches the pattern
 # "v*" (e.g. v0.1.0) is created.
 on:
+  # on pushes to either the specified branch or a version tag - see:
+  # https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#example-including-branches-and-tags
   push:
     tags:
       - 'v*'
+    branches:
+      - main
 
 jobs:
+  # bump the version if not manually tagged
+  version:
+    id: version
+    if: github.ref_type != 'tag'
+    uses: mathieudutour/github-tag-action@v6.2  
+    permissions:
+      contents: write  # Required push tags.
+    with:
+      create_annotated_tag: false
+      default_bump: patch
+      default_prerelease_bump: prepatch
+      github_token: ${{ github.token }}
+      pre_release_branches: .*
+      release_branches: main
+      tag_prefix: v
+    
   # Release for Partner and Community Providers
   terraform-provider-release:
+    environment: 'Hashicorp Registry'
     name: 'Terraform Provider Release'
     uses: hashicorp/ghaction-terraform-provider-release/.github/workflows/community.yml@v5.0.0
     secrets:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
   version:
     id: version
     if: github.ref_type != 'tag'
-    uses: mathieudutour/github-tag-action@v6.2  
+    uses: mathieudutour/github-tag-action@v6.2
     permissions:
       contents: write  # Required push tags.
     with:
@@ -28,7 +28,7 @@ jobs:
       pre_release_branches: .*
       release_branches: main
       tag_prefix: v
-    
+
   # Release for Partner and Community Providers
   terraform-provider-release:
     environment: 'Hashicorp Registry'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,13 +6,17 @@ on:
   pull_request:
     branches:
       - main
+      - release
     paths-ignore:
       - 'README.md'
+      - '.github/workflows/*.yml'
   push:
     branches:
       - main
+      - release
     paths-ignore:
       - 'README.md'
+      - '.github/workflows/*.yml'
 
 # Testing only needs permissions to read the repository contents.
 permissions:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,81 +1,81 @@
 ---
-  # Terraform Provider testing workflow.
-  name: Tests
-  
-  on:
-    pull_request:
-      branches:
-        - main
-      paths-ignore:
-        - 'README.md'
-    push:
-      branches:
-        - main
-      paths-ignore:
-        - 'README.md'
-  
-  # Testing only needs permissions to read the repository contents.
-  permissions:
-    contents: read
-  
-  jobs:
-    # Ensure project builds before running testing matrix
-    build:
-      name: Build
-      runs-on: ubuntu-latest
-      timeout-minutes: 5
-      steps:
-        - uses: actions/checkout@v4
-        - uses: actions/setup-go@v5
-          with:
-            go-version-file: 'go.mod'
-            cache: true
-        - run: go mod download
-        - run: go build -v .
-  
-    generate:
-      runs-on: ubuntu-latest
-      steps:
-        - uses: actions/checkout@v4
-        - uses: actions/setup-go@v5
-          with:
-            go-version-file: 'go.mod'
-            cache: true
-        - run: go generate ./...
-        - name: git diff
-          run: |
-            git diff --compact-summary --exit-code || \
-              (echo; echo "Unexpected difference in directories after code generation. Run 'go generate ./...' command and commit."; exit 1)
-  
-    # Run acceptance tests in a matrix with Terraform CLI versions
-    test:
-      name: Terraform Provider Acceptance Tests
-      needs: build
-      runs-on: ubuntu-latest
-      timeout-minutes: 15
-      strategy:
-        fail-fast: false
-        matrix:
-          # list whatever Terraform versions here you would like to support
-          terraform:
-            - '1.6.*'
-            - '1.7.*'
-            - '1.8.*'
-            - '1.9.*'
-      steps:
-        - uses: actions/checkout@v4
-        - uses: actions/setup-go@v5
-          with:
-            go-version-file: 'go.mod'
-            cache: true
-        - uses: hashicorp/setup-terraform@v3
-          with:
-            terraform_version: ${{ matrix.terraform }}
-            terraform_wrapper: false
-        - run: go mod download
-        - env:
-            TF_ACC: "1"
-            JAMFPRO_TENANT_ID: ${{ secrets.JAMFPRO_TENANT_ID }}
-            JAMFPRO_CLIENT_ID: ${{ secrets.JAMFPRO_CLIENT_ID }}
-          run: go test -v -cover ./internal/
-          timeout-minutes: 10
+# Terraform Provider testing workflow.
+name: Tests
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - 'README.md'
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - 'README.md'
+
+# Testing only needs permissions to read the repository contents.
+permissions:
+  contents: read
+
+jobs:
+  # Ensure project builds before running testing matrix
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+      - run: go mod download
+      - run: go build -v .
+
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+      - run: go generate ./...
+      - name: git diff
+        run: |
+          git diff --compact-summary --exit-code || \
+            (echo; echo "Unexpected difference in directories after code generation. Run 'go generate ./...' command and commit."; exit 1)
+
+  # Run acceptance tests in a matrix with Terraform CLI versions
+  test:
+    name: Terraform Provider Acceptance Tests
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        # list whatever Terraform versions here you would like to support
+        terraform:
+          - '1.6.*'
+          - '1.7.*'
+          - '1.8.*'
+          - '1.9.*'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ matrix.terraform }}
+          terraform_wrapper: false
+      - run: go mod download
+      - env:
+          TF_ACC: "1"
+          JAMFPRO_TENANT_ID: ${{ secrets.JAMFPRO_TENANT_ID }}
+          JAMFPRO_CLIENT_ID: ${{ secrets.JAMFPRO_CLIENT_ID }}
+        run: go test -v -cover ./internal/
+        timeout-minutes: 10

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,33 +6,33 @@ before:
     # this is just an example and not a requirement for provider building/publishing
     - go mod tidy
 builds:
-- env:
-    # goreleaser does not work with CGO, it could also complicate
-    # usage by users in CI/CD systems like Terraform Cloud where
-    # they are unable to install libraries.
-    - CGO_ENABLED=0
-  mod_timestamp: '{{ .CommitTimestamp }}'
-  flags:
-    - -trimpath
-  ldflags:
-    - '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}'
-  goos:
-    - freebsd
-    - windows
-    - linux
-    - darwin
-  goarch:
-    - amd64
-    - '386'
-    - arm
-    - arm64
-  ignore:
-    - goos: darwin
-      goarch: '386'
-  binary: '{{ .ProjectName }}_v{{ .Version }}'
+  - env:
+      # goreleaser does not work with CGO, it could also complicate
+      # usage by users in CI/CD systems like Terraform Cloud where
+      # they are unable to install libraries.
+      - CGO_ENABLED=0
+    mod_timestamp: '{{ .CommitTimestamp }}'
+    flags:
+      - -trimpath
+    ldflags:
+      - '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}'
+    goos:
+      - freebsd
+      - windows
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - '386'
+      - arm
+      - arm64
+    ignore:
+      - goos: darwin
+        goarch: '386'
+    binary: '{{ .ProjectName }}_v{{ .Version }}'
 archives:
-- format: zip
-  name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+  - format: zip
+    name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
 checksum:
   extra_files:
     - glob: 'terraform-registry-manifest.json'
@@ -42,7 +42,7 @@ checksum:
 signs:
   - artifacts: checksum
     args:
-      # if you are using this in a GitHub action or some other automated pipeline, you 
+      # if you are using this in a GitHub action or some other automated pipeline, you
       # need to pass the batch flag to indicate its not interactive.
       - "--batch"
       - "--local-user"

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,34 @@
+---
+yaml-files:
+  - '*.yaml'
+  - '*.yml'
+  - '.yamllint'
+
+rules:
+  anchors: enable
+  braces: enable
+  brackets: disable
+  colons: enable
+  commas: enable
+  comments: disable
+  comments-indentation: disable
+  document-end: disable
+  document-start: disable
+  empty-lines: enable
+  empty-values: disable
+  float-values: disable
+  hyphens: enable
+  indentation: enable
+  key-duplicates: enable
+  key-ordering: disable
+  line-length:
+    max: 500
+    level: warning
+  new-line-at-end-of-file: disable
+  new-lines: enable
+  octal-values: disable
+  quoted-strings: disable
+  trailing-spaces: enable
+  truthy:
+    level: warning
+    check-keys: false

--- a/README.md
+++ b/README.md
@@ -64,6 +64,20 @@ For further community support and to engage with other users of the Jamf Pro Ter
 
 - [Mac Admins Slack Channel](https://macadmins.slack.com/archives/C06R172PUV6) - #terraform-provider-jamfpro
 
+## Development
+### Releases
+* New releases are created and deployed to hashicorp's terraform registry on commit pushes to `main` branch (includes merges) or version tag (`v*`) pushes to any branch.
+* New prereleases are created and deployed to hashicorp's terraform registry on pushes to `development` branch.
+* Commit pushes have a bumped version tag automatically applied. The default semantic bump is `{pre}patch`. 
+  * Commit message keywords can override this to minor or major with the following ruleset:
+    - `fix:patch,bug:patch,bugfix:patch,patch:patch,feat:patch,feat:minor:new resource,minor:minor,feat:major:breaking change,feat:major:API change,major:major`
+    - Rule format: `<keyword>:<release_type>:<changelog_section>`
+    - [Docs](https://github.com/mathieudutour/github-tag-action?tab=readme-ov-file#customize-the-conventional-commit-messages--titles-of-changelog-sections)
+
+### How to create a release
+* Open or merge a PR to `main` (creates release) or `development` (creates prerelease).
+* Push a version tag to any branch: `git tag "v0.0.1" && git push --tags` (creates release).
+
 ## Getting Started with Examples
 
 # Provider Configuration for Jamf Pro in Terraform

--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ For further community support and to engage with other users of the Jamf Pro Ter
     - [Docs](https://github.com/mathieudutour/github-tag-action?tab=readme-ov-file#customize-the-conventional-commit-messages--titles-of-changelog-sections)
 
 ### How to create a release
-* Open or merge a PR to `main` (creates release) or `development` (creates prerelease).
-* Push a version tag to any branch: `git tag "v0.0.1" && git push --tags` (creates release).
+* Open a PR, wait for tests, merge the PR, wait for tests. Applies to branches `main` (creates release) and `development` (creates prerelease).
+* Push a version tag to any protected branch: `git tag "v0.0.1" && git push --tags` (creates release).
 
 ## Getting Started with Examples
 

--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ For further community support and to engage with other users of the Jamf Pro Ter
 
 ## Development
 ### Releases
-* New releases are created and deployed to hashicorp's terraform registry on commit pushes to `main` branch (includes merges) or version tag (`v*`) pushes to any branch.
-* New prereleases are created and deployed to hashicorp's terraform registry on pushes to `development` branch.
-* Commit pushes have a bumped version tag automatically applied. The default semantic bump is `{pre}patch`. 
+* New releases are created and deployed to hashicorp's terraform registry on commit pushes to `release` branch (includes merges) or version tag (`v*`) pushes to any branch.
+* New prereleases are created and deployed to hashicorp's terraform registry on pushes to `main` branch.
+* Commit pushes have a bumped version tag automatically applied. The default semantic bump is `patch` (`prepatch` for pushes to `main`).
   * Commit message keywords can override this to minor or major with the following ruleset:
     - `fix:patch,bug:patch,bugfix:patch,patch:patch,feat:patch,feat:minor:new resource,minor:minor,feat:major:breaking change,feat:major:API change,major:major`
     - Rule format: `<keyword>:<release_type>:<changelog_section>`


### PR DESCRIPTION
**This PR should not be merged before several changes are made to the repo's settings**.

## Changes
- Adds an auto-version bump job to release.yml. Uses [mathieudutour/github-tag-action](https://github.com/mathieudutour/github-tag-action).
- Adds two triggers to same workflow: on pushes to `main` and `release` branches.
- Adds an `environment:` value to the Terraform Provider Release job. This makes the job a Github Deployment.
- Adds releases documentation to README.
- Adds yamllint step to lint job; adds permissive yamllint config; fixes some yamllint'd issues in various yamls.

## Required settings changes
- Create a new environment (Settings -> Environments) named 'terraform registry'. Set 'Deployment branches and tags' to 'Protected branches only':
<img width="694" alt="Screenshot 2024-08-14 at 6 45 45 PM" src="https://github.com/user-attachments/assets/59addc90-079e-4d32-b351-5294fac9ec07">
 
 - This will restrict the Terraform Provider job from ever running - that is, deploying to 'hashicorp registry' - on an unprotected branch.
- Set the `main` branch as protected (Settings -> Branches) (believe it already is). 
- Create a `release` branch and protect it similarly - but also restrict admins' ability to evade protection w/ a force push.

## How this will change release & dev flows
In this design, every time you merge a PR with main, a new prerelease will be automatically built and deployed to the Terraform Registry (provided tests.yml passes). When you're ready to make a full release, open a PR main->release. Admins can still push their changes directly to main, but doing so should be done more judiciously.

Tag pushes can still be used to manually create a release from any branch (but deployment will fail if the branch is not protected). The auto version bump is skipped in these cases.

## Some possible variations on this design
* You may optionally enable 'Required reviewers' for the 'terraform registry' environment. This will prevent the release job from proceeding until approved.
* We can create a `prerelease` branch instead of deploying `main`. This would allow folks to continue to commit to main - and permit manual releases from main w/ version tag - while still at least notionally locking down releases.
* Or just use the `release` branch, and never deploy prereleases or releases from `main` or any other branch (save when a protected branch is tagged).

If any of these - or any other delta - seems better to y'all, let me know and I'll amend this patch accordingly.
