### PR TITLE
bug fix (staticcomputergroups): modifying static computer group membership always fails

### DIFF
--- a/internal/resources/staticcomputergroups/constructor.go
+++ b/internal/resources/staticcomputergroups/constructor.go
@@ -20,15 +20,15 @@ func construct(d *schema.ResourceData) (*jamfpro.ResourceComputerGroup, error) {
 
 	resource.Site = sharedschemas.ConstructSharedResourceSite(d.Get("site_id").(int))
 
-	if resource.Computers != nil {
-		assignedComputers := d.Get("assigned_computer_ids").([]interface{})
-		if len(assignedComputers) > 0 {
-			for _, v := range assignedComputers {
-				*resource.Computers = append(*resource.Computers, jamfpro.ComputerGroupSubsetComputer{
-					ID: v.(int),
-				})
-			}
+	assignedComputers := d.Get("assigned_computer_ids").([]interface{})
+	if len(assignedComputers) > 0 {
+		computers := []jamfpro.ComputerGroupSubsetComputer{}
+		for _, v := range assignedComputers {
+			computers = append(computers, jamfpro.ComputerGroupSubsetComputer{
+				ID: v.(int),
+			})
 		}
+		resource.Computers = &computers
 	}
 
 	resourceXML, err := xml.MarshalIndent(resource, "", "  ")


### PR DESCRIPTION
`resource.Computers` is always `nil`, since its instantiated at beginning of `func construct`. Checking this always prevents it from being correctly constructed from `assigned_computer_ids`. 

[Unlike](https://github.com/deploymenttheory/go-api-sdk-jamfpro/blob/main/sdk/jamfpro/classicapi_usergroups.go#L50) `ResourceUserGroup.Users`, `ResourceComputerGroup.Computers` [is a pointer](https://github.com/deploymenttheory/go-api-sdk-jamfpro/blob/main/sdk/jamfpro/classicapi_computer_groups.go#L42). (Which is optimal? I'm not sure, [but probably not pointers, sans a specific reason](https://stackoverflow.com/questions/59964619/difference-using-pointer-in-struct-fields).)