### PR TITLE
Always use "-1" for prestage location_information, purchasing_information, and account_settings IDs

### DIFF
--- a/internal/resources/computerprestageenrollments/constructor.go
+++ b/internal/resources/computerprestageenrollments/constructor.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"strconv"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -163,11 +162,8 @@ func constructLocationInformation(data map[string]interface{}, isUpdate bool, ve
 		d.Set(k, v)
 	}
 
-	newID := handleNestedID(data, isUpdate)
-	log.Printf("[DEBUG] constructLocationInformation: Using ID '%s'", newID)
-
 	return jamfpro.ComputerPrestageSubsetLocationInformation{
-		ID:           newID,
+		ID:           "-1",
 		VersionLock:  versionLock,
 		Username:     data["username"].(string),
 		Realname:     data["realname"].(string),
@@ -187,11 +183,8 @@ func constructPurchasingInformation(data map[string]interface{}, isUpdate bool, 
 		d.Set(k, v)
 	}
 
-	newID := handleNestedID(data, isUpdate)
-	log.Printf("[DEBUG] constructPurchasingInformation: Using ID '%s'", newID)
-
 	return jamfpro.ComputerPrestageSubsetPurchasingInformation{
-		ID:                newID,
+		ID:                "-1",
 		VersionLock:       versionLock,
 		Leased:            jamfpro.BoolPtr(data["leased"].(bool)),
 		Purchased:         jamfpro.BoolPtr(data["purchased"].(bool)),
@@ -210,11 +203,8 @@ func constructPurchasingInformation(data map[string]interface{}, isUpdate bool, 
 
 // constructAccountSettings constructs the AccountSettings subset of a Computer Prestage resource.
 func constructAccountSettings(data map[string]interface{}, isUpdate bool, versionLock int) jamfpro.ComputerPrestageSubsetAccountSettings {
-	newID := handleNestedID(data, isUpdate)
-	log.Printf("[DEBUG] constructAccountSettings: Using ID '%s'", newID)
-
 	return jamfpro.ComputerPrestageSubsetAccountSettings{
-		ID:                                      newID,
+		ID:                                      "-1",
 		VersionLock:                             versionLock,
 		PayloadConfigured:                       jamfpro.BoolPtr(data["payload_configured"].(bool)),
 		LocalAdminAccountEnabled:                jamfpro.BoolPtr(data["local_admin_account_enabled"].(bool)),
@@ -280,22 +270,6 @@ func handleVersionLock(currentVersionLock interface{}, isUpdate bool) int {
 func getHCLStringOrDefaultInteger(d *schema.ResourceData, key string) string {
 	if v, ok := d.GetOk(key); ok {
 		return v.(string)
-	}
-	return "-1"
-}
-
-// handleNestedID manages the ID field for nested structures within a Computer Prestage resource.
-func handleNestedID(data map[string]interface{}, isUpdate bool) string {
-	if id, ok := data["id"]; ok && id.(string) != "" {
-		if isUpdate {
-			currentID, err := strconv.Atoi(id.(string))
-			if err != nil {
-				log.Printf("[WARN] Failed to convert ID '%s' to integer: %v. Using original value.", id.(string), err)
-				return id.(string)
-			}
-			return strconv.Itoa(currentID + 1)
-		}
-		return id.(string)
 	}
 	return "-1"
 }

--- a/internal/resources/computerprestageenrollments/state.go
+++ b/internal/resources/computerprestageenrollments/state.go
@@ -2,6 +2,8 @@
 package computerprestageenrollments
 
 import (
+	"sort"
+
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -36,7 +38,6 @@ func updateState(d *schema.ResourceData, resp *jamfpro.ResourceComputerPrestage)
 		"region":                                resp.Region,
 		"auto_advance_setup":                    resp.AutoAdvanceSetup,
 		"install_profiles_during_setup":         resp.InstallProfilesDuringSetup,
-		"prestage_installed_profile_ids":        resp.PrestageInstalledProfileIds,
 		"custom_package_ids":                    resp.CustomPackageIds,
 		"custom_package_distribution_point_id":  resp.CustomPackageDistributionPointId,
 		"enable_recovery_lock":                  resp.EnableRecoveryLock,
@@ -65,6 +66,10 @@ func updateState(d *schema.ResourceData, resp *jamfpro.ResourceComputerPrestage)
 		// "session_timeout":                                      resp.SessionTimeout,
 		// "device_type":                                          resp.DeviceType,
 	}
+
+	prestageInstalledProfileIds := resp.PrestageInstalledProfileIds
+	sort.Strings(prestageInstalledProfileIds)
+	prestageAttributes["prestage_installed_profile_ids"] = prestageInstalledProfileIds
 
 	if locationInformation := resp.LocationInformation; locationInformation != (jamfpro.ComputerPrestageSubsetLocationInformation{}) {
 		prestageAttributes["location_information"] = []interface{}{

--- a/internal/resources/computerprestageenrollments/state.go
+++ b/internal/resources/computerprestageenrollments/state.go
@@ -2,8 +2,6 @@
 package computerprestageenrollments
 
 import (
-	"sort"
-
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -38,6 +36,7 @@ func updateState(d *schema.ResourceData, resp *jamfpro.ResourceComputerPrestage)
 		"region":                                resp.Region,
 		"auto_advance_setup":                    resp.AutoAdvanceSetup,
 		"install_profiles_during_setup":         resp.InstallProfilesDuringSetup,
+		"prestage_installed_profile_ids":        resp.PrestageInstalledProfileIds,
 		"custom_package_ids":                    resp.CustomPackageIds,
 		"custom_package_distribution_point_id":  resp.CustomPackageDistributionPointId,
 		"enable_recovery_lock":                  resp.EnableRecoveryLock,
@@ -66,10 +65,6 @@ func updateState(d *schema.ResourceData, resp *jamfpro.ResourceComputerPrestage)
 		// "session_timeout":                                      resp.SessionTimeout,
 		// "device_type":                                          resp.DeviceType,
 	}
-
-	prestageInstalledProfileIds := resp.PrestageInstalledProfileIds
-	sort.Strings(prestageInstalledProfileIds)
-	prestageAttributes["prestage_installed_profile_ids"] = prestageInstalledProfileIds
 
 	if locationInformation := resp.LocationInformation; locationInformation != (jamfpro.ComputerPrestageSubsetLocationInformation{}) {
 		prestageAttributes["location_information"] = []interface{}{


### PR DESCRIPTION
When attempting to update prestages on an environment with multiple pre-existing prestages, I get the following 409 Conflict response:

```terraform
  # module.zoom.jamfpro_computer_prestage_enrollment.zoom_rooms will be updated in-place
  ~ resource "jamfpro_computer_prestage_enrollment" "zoom_rooms" {
      ~ auto_advance_setup                    = false -> true
        id                                    = "4"
      ~ install_profiles_during_setup         = false -> true
      ~ keep_existing_site_membership         = false -> true
      ~ prestage_installed_profile_ids        = [
          + "175",
          + "174",
          + "172",
          + "171",
          + "170",
          + "173",
          + "177",
        ]
      + region                                = "US"
      + support_email_address                 = "it+zoom-rooms@faire.com"
        # (20 unchanged attributes hidden)

      ~ purchasing_information {
            id              = "4"
          ~ life_expectancy = 0 -> 3
            # (6 unchanged attributes hidden)
        }

      ~ skip_setup_items {
          ~ display_tone       = false -> true
          ~ location           = false -> true
            # (16 unchanged attributes hidden)
        }

        # (2 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

```
╷
│ Error: failed to update Jamf Pro Computer Prestage Enrollment 'Zoom Rooms' (ID: 4) after retries: 
| failed to update computer prestage with ID 4: {"status_code":409,"method":"PUT","url":"https://faire.jamfcloud.com/api/v3/computer-prestages/4","message":"API Error Response","raw_response":""}
│ 
│   with module.zoom.jamfpro_computer_prestage_enrollment.zoom_rooms,
│   on modules/mac-type/prestage.tf line 1, in resource "jamfpro_computer_prestage_enrollment" "zoom_rooms":
│    1: resource "jamfpro_computer_prestage_enrollment" "zoom_rooms" {
│ 
╵
```

This appears to be because one or more of the calculated IDs for `{purchasing,location}_information` and `account_settings` already exists, associated with another prestage. Jamf server logs don't confirm this, the error message is uninformative, and Jamf has no API or GUI for directly inspecting these objects and their IDs. 

However, setting the IDs to "-1" fixes the issue. Assuming we're creating, and wish to create, new versions of these objects on every update, "-1" seems the correct value, per the pattern used when creating other objects over Jamf's API. Their docs also imply this:
<img width="661" alt="Screenshot 2024-09-09 at 7 21 46 PM" src="https://github.com/user-attachments/assets/110984ac-11a8-44d1-b5ff-e705850a591a">

I'm not 100% sure how "-1" should interact with version lock, but I suspect changing the ID to match the version would be incorrect. Setting "-1" and specifying a locked version should hopefully induce Jamf to modify the correct object version. (Tbh I also doubt if the provider's incrementation of the operator's provided version lock is a good idea, but haven't seen a bug with it as yet.)