### PR TITLE
fix: incorrectly named SetId value in activationcode

### DIFF
--- a/internal/resources/activationcode/crud.go
+++ b/internal/resources/activationcode/crud.go
@@ -42,7 +42,7 @@ func read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Di
 	client := meta.(*jamfpro.Client)
 	var diags diag.Diagnostics
 
-	d.SetId("jamfpro_computer_checkin_singleton")
+	d.SetId("jamfpro_activation_code_singleton")
 
 	var response *jamfpro.ResourceActivationCode
 	err := retry.RetryContext(ctx, d.Timeout(schema.TimeoutRead), func() *retry.RetryError {


### PR DESCRIPTION
In the activationcode package, `SetId` is assigned the value `jamfpro_computer_checkin_singleton` on read operations, rather than `jamfpro_activation_code_singleton`. 

Purely a cosmetic bug that shows up in terraform plan output when importing the `jamfpro_activation_code` resource in an `import` block

```
  # jamfpro_activation_code.testenv_activation_code will be updated in-place
  # (imported from "activation_code_singleton")
  ~ resource "jamfpro_activation_code" "testenv_activation_code" {
      # Warning: this attribute value will be marked as sensitive and will not
      # display in UI output after applying this change.
      ~ code              = (sensitive value)
        id                = "jamfpro_computer_checkin_singleton"
        organization_name = "My Test Environment"
```