### PR TITLE
Fix Changes made to 4 schema type lists to type sets

### DIFF
--- a/examples/resources/jamfpro_computer_prestage_enrollments/resource.tf
+++ b/examples/resources/jamfpro_computer_prestage_enrollments/resource.tf
@@ -167,9 +167,9 @@ resource "jamfpro_computer_prestage_enrollment" "configured_example_1" {
   region                                  = ""
   auto_advance_setup                      = false
   install_profiles_during_setup           = true
-  prestage_installed_profile_ids          = reverse(sort([3114, 3800])) // requires decending order
-  custom_package_ids                      = sort([1, 2])                // requires ascending order
-  custom_package_distribution_point_id    = "-2"                        // "-1" - not used / "-2" - Cloud Distribution Point (Jamf Cloud) / "any other number" - Distribution Point ID
+  prestage_installed_profile_ids          = [3114, jamfpro_macos_configuration_profile_plist.jamfpro_macos_configuration_profile_001.id]
+  custom_package_ids                      = [1, 2]        
+  custom_package_distribution_point_id    = "-2"     // "-1" - not used / "-2" - Cloud Distribution Point (Jamf Cloud) / "any other number" - Distribution Point ID
   enable_recovery_lock                    = true
   recovery_lock_password_type             = "MANUAL" // "MANUAL" / "RANDOM"
   recovery_lock_password                  = "thing"

--- a/internal/resources/computerprestageenrollments/constructor.go
+++ b/internal/resources/computerprestageenrollments/constructor.go
@@ -96,14 +96,16 @@ func construct(d *schema.ResourceData, isUpdate bool) (*jamfpro.ResourceComputer
 
 	resource.PrestageInstalledProfileIds = make([]string, 0)
 	if v, ok := d.GetOk("prestage_installed_profile_ids"); ok {
-		for _, id := range v.([]interface{}) {
+		profileSet := v.(*schema.Set)
+		for _, id := range profileSet.List() {
 			resource.PrestageInstalledProfileIds = append(resource.PrestageInstalledProfileIds, id.(string))
 		}
 	}
 
 	resource.CustomPackageIds = make([]string, 0)
 	if v, ok := d.GetOk("custom_package_ids"); ok {
-		for _, id := range v.([]interface{}) {
+		packageSet := v.(*schema.Set)
+		for _, id := range packageSet.List() {
 			resource.CustomPackageIds = append(resource.CustomPackageIds, id.(string))
 		}
 	}

--- a/internal/resources/computerprestageenrollments/resource.go
+++ b/internal/resources/computerprestageenrollments/resource.go
@@ -409,19 +409,19 @@ func ResourceJamfProComputerPrestageEnrollmentEnrollment() *schema.Resource {
 				Description: "Indicates if profiles should be installed during setup.",
 			},
 			"prestage_installed_profile_ids": {
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Required:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
-				Description: "IDs of the macOS configuration profiles installed during PreStage enrollment. requires decending order of profile IDs. can be left blank.",
+				Description: "IDs of the macOS configuration profiles installed during PreStage enrollment. requires decending order of profile IDs so uses a set rather than a list. can be left blank.",
 			},
 			"custom_package_ids": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Required: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
-				Description: "Define the Enrollment Packages by their package ID to" +
-					"add an enrollment package to the PreStage enrollment. Compatible packages" +
-					"must be built as flat, distribution style .pkg files and be signed by a" +
-					"certificate that is trusted by managed computers. requires ascending order of package IDs. Can be left blank.",
+				Description: "Define the Enrollment Packages by their package ID to " +
+					"add an enrollment package to the PreStage enrollment. Compatible packages " +
+					"must be built as flat, distribution style .pkg files and be signed by a " +
+					"certificate that is trusted by managed computers. requires ascending order of package IDs so uses a set rather than a lsit. Can be left blank.",
 			},
 			"custom_package_distribution_point_id": {
 				Type:     schema.TypeString,

--- a/internal/resources/macosconfigurationprofilesplistgenerator/constructor.go
+++ b/internal/resources/macosconfigurationprofilesplistgenerator/constructor.go
@@ -186,21 +186,21 @@ func constructMacOSConfigurationProfileSubsetSelfService(data map[string]interfa
 		NotificationMessage:         data["notification_message"].(string),
 	}
 
-	if categories, ok := data["self_service_categories"]; ok {
-		selfService.SelfServiceCategories = constructSelfServiceCategories(categories.([]interface{}))
+	if categories, ok := data["self_service_category"]; ok {
+		selfService.SelfServiceCategories = constructSelfServiceCategories(categories.(*schema.Set))
 	}
 
 	return selfService
 }
 
 // constructSelfServiceCategories constructs a slice of MacOSConfigurationProfileSubsetSelfServiceCategory from the provided schema data.
-func constructSelfServiceCategories(categories []interface{}) []jamfpro.MacOSConfigurationProfileSubsetSelfServiceCategory {
-	selfServiceCategories := make([]jamfpro.MacOSConfigurationProfileSubsetSelfServiceCategory, len(categories))
-	for i, category := range categories {
+func constructSelfServiceCategories(categories *schema.Set) []jamfpro.MacOSConfigurationProfileSubsetSelfServiceCategory {
+	categoryList := categories.List()
+	selfServiceCategories := make([]jamfpro.MacOSConfigurationProfileSubsetSelfServiceCategory, len(categoryList))
+	for i, category := range categoryList {
 		catData := category.(map[string]interface{})
 		selfServiceCategories[i] = jamfpro.MacOSConfigurationProfileSubsetSelfServiceCategory{
 			ID:        catData["id"].(int),
-			Name:      catData["name"].(string),
 			DisplayIn: catData["display_in"].(bool),
 			FeatureIn: catData["feature_in"].(bool),
 		}

--- a/internal/resources/macosconfigurationprofilesplistgenerator/resource.go
+++ b/internal/resources/macosconfigurationprofilesplistgenerator/resource.go
@@ -389,7 +389,7 @@ func ResourceJamfProMacOSConfigurationProfilesPlistGenerator() *schema.Resource 
 						// 	},
 						// }, // TODO fix this broken crap later
 						"self_service_categories": {
-							Type:        schema.TypeList,
+							Type:        schema.TypeSet,
 							Description: "Self Service category options",
 							Optional:    true,
 							Elem: &schema.Resource{


### PR DESCRIPTION
within plist, plist_generator and computer prestage environments. 

This resolves stating issues when jamfpro returns varying approaches to sequencing id's. they can go up, then can go down, they can be random. So sets make sense.