### PR TITLE
Fix diff suppression logic for plist config profiles for computers and mobile devices + updated schema docs

### DIFF
--- a/docs/resources/advanced_mobile_device_search.md
+++ b/docs/resources/advanced_mobile_device_search.md
@@ -61,7 +61,7 @@ resource "jamfpro_advanced_mobile_device_search" "advanced_mobile_device_search_
 
 Required:
 
-- `and_or` (String) Logical operator (and/or) for the criteria
+- `and_or` (String) Logical operator (and/or) for the search criteria
 - `name` (String) Name of the search criteria field
 - `search_type` (String) Type of search to perform
 - `value` (String) Value to search for

--- a/docs/resources/computer_prestage_enrollment.md
+++ b/docs/resources/computer_prestage_enrollment.md
@@ -16,7 +16,7 @@ description: |-
 - `authentication_prompt` (String) Authentication Message to display to the user. Used when Require Authentication is enabled. Can be left blank.
 - `auto_advance_setup` (Boolean) Indicates if setup should auto-advance.
 - `custom_package_distribution_point_id` (String) Set the Enrollment Packages distribution point by it's ID.Valid values are: None using '-1', Cloud Distribution Point (Jamf Cloud)by using '-2', else all other valid valid values correspond to theID of the distribution point.
-- `custom_package_ids` (List of String) Define the Enrollment Packages by their package ID toadd an enrollment package to the PreStage enrollment. Compatible packagesmust be built as flat, distribution style .pkg files and be signed by acertificate that is trusted by managed computers. requires ascending order of package IDs. Can be left blank.
+- `custom_package_ids` (Set of String) Define the Enrollment Packages by their package ID to add an enrollment package to the PreStage enrollment. Compatible packages must be built as flat, distribution style .pkg files and be signed by a certificate that is trusted by managed computers. Can be left blank.
 - `default_prestage` (Boolean) Indicates if this is the default computer prestage enrollment configuration. If yes then new devices will be automatically assigned to this PreStage enrollment
 - `department` (String) The department the computer prestage is assigned to. Can be left blank.
 - `device_enrollment_program_instance_id` (String) The Automated Device Enrollment instance ID to associate with the PreStage enrollment. Devices associated with the selected Automated Device Enrollment instance can be assigned the PreStage enrollment
@@ -32,7 +32,7 @@ description: |-
 - `location_information` (Block List, Min: 1) Location information associated with the Jamf Pro computer prestage. (see [below for nested schema](#nestedblock--location_information))
 - `mandatory` (Boolean) Make MDM Profile Mandatory and require the user to apply the MDM profile. Computers with macOS 10.15 or later automatically require the user to apply the MDM profile
 - `mdm_removable` (Boolean) Allow MDM Profile Removal and allow the user to remove the MDM profile.
-- `prestage_installed_profile_ids` (List of String) IDs of the macOS configuration profiles installed during PreStage enrollment. requires decending order of profile IDs. can be left blank.
+- `prestage_installed_profile_ids` (Set of String) IDs of the macOS configuration profiles installed during PreStage enrollment. requires decending order of profile IDs so uses a set rather than a list. can be left blank.
 - `prestage_minimum_os_target_version_type` (String) Enforce a minimum macOS target version type for the prestage enrollment. Required.
 - `prevent_activation_lock` (Boolean) Prevent user from enabling Activation Lock.
 - `purchasing_information` (Block List, Min: 1) Purchasing information associated with the computer prestage. (see [below for nested schema](#nestedblock--purchasing_information))

--- a/docs/resources/macos_configuration_profile_plist_generator.md
+++ b/docs/resources/macos_configuration_profile_plist_generator.md
@@ -397,7 +397,7 @@ Optional:
 - `notification` (Boolean) Enables Notification for this profile in self service
 - `notification_message` (String) Message body
 - `notification_subject` (String) Message Subject
-- `self_service_categories` (Block List) Self Service category options (see [below for nested schema](#nestedblock--self_service--self_service_categories))
+- `self_service_categories` (Block Set) Self Service category options (see [below for nested schema](#nestedblock--self_service--self_service_categories))
 - `self_service_description` (String) Description shown in Self Service
 
 <a id="nestedblock--self_service--self_service_categories"></a>

--- a/internal/resources/computerprestageenrollments/resource.go
+++ b/internal/resources/computerprestageenrollments/resource.go
@@ -421,7 +421,7 @@ func ResourceJamfProComputerPrestageEnrollmentEnrollment() *schema.Resource {
 				Description: "Define the Enrollment Packages by their package ID to " +
 					"add an enrollment package to the PreStage enrollment. Compatible packages " +
 					"must be built as flat, distribution style .pkg files and be signed by a " +
-					"certificate that is trusted by managed computers. requires ascending order of package IDs so uses a set rather than a lsit. Can be left blank.",
+					"certificate that is trusted by managed computers. Can be left blank.",
 			},
 			"custom_package_distribution_point_id": {
 				Type:     schema.TypeString,

--- a/internal/resources/macosconfigurationprofilesplist/data_validator.go
+++ b/internal/resources/macosconfigurationprofilesplist/data_validator.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-// mainCustomDiffFunc orchestrates all custom diff validations.
+// mainCustomDiffFunc orchestrates all custom diff validations for macOS config profiles.
 func mainCustomDiffFunc(ctx context.Context, diff *schema.ResourceDiff, i interface{}) error {
 	if diff.Get("payload_validate").(bool) {
 		if err := validatePayload(ctx, diff, i); err != nil {
@@ -28,23 +28,18 @@ func mainCustomDiffFunc(ctx context.Context, diff *schema.ResourceDiff, i interf
 		if err := validateMacOSConfigurationProfileLevel(ctx, diff, i); err != nil {
 			return err
 		}
+	}
 
-		if err := validateConfigurationProfileFormatting(ctx, diff, i); err != nil {
-			return err
-		}
+	if err := validateSelfServiceCategories(ctx, diff, i); err != nil {
+		return err
+	}
 
-		if err := validateSelfServiceCategories(ctx, diff, i); err != nil {
-			return err
-		}
+	if err := validateAllComputersScope(ctx, diff, i); err != nil {
+		return err
+	}
 
-		if err := validateAllComputersScope(ctx, diff, i); err != nil {
-			return err
-		}
-
-		if err := validateAllUsersScope(ctx, diff, i); err != nil {
-			return err
-		}
-
+	if err := validateAllUsersScope(ctx, diff, i); err != nil {
+		return err
 	}
 
 	return nil
@@ -117,18 +112,6 @@ func validateMacOSConfigurationProfileLevel(_ context.Context, diff *schema.Reso
 
 	if payloadScope != level {
 		return fmt.Errorf("in 'jamfpro_macos_configuration_profile.%s': hcl 'level' attribute (%s) does not match the 'PayloadScope' in the root dict of the plist (%s); the values must be identical", resourceName, level, payloadScope)
-	}
-
-	return nil
-}
-
-// validateConfigurationProfileFormatting validates the indentation of the plist XML.
-func validateConfigurationProfileFormatting(_ context.Context, diff *schema.ResourceDiff, _ interface{}) error {
-	resourceName := diff.Get("name").(string)
-	payloads := diff.Get("payloads").(string)
-
-	if err := datavalidators.CheckPlistIndentationAndWhiteSpace(payloads); err != nil {
-		return fmt.Errorf("in 'jamfpro_macos_configuration_profile.%s': %v", resourceName, err)
 	}
 
 	return nil

--- a/internal/resources/macosconfigurationprofilesplist/payload_diff_suppress.go
+++ b/internal/resources/macosconfigurationprofilesplist/payload_diff_suppress.go
@@ -2,7 +2,7 @@
 package macosconfigurationprofilesplist
 
 import (
-	"log"
+	"fmt"
 
 	"github.com/deploymenttheory/terraform-provider-jamfpro/internal/resources/common"
 	"github.com/deploymenttheory/terraform-provider-jamfpro/internal/resources/common/configurationprofiles/plist"
@@ -11,43 +11,38 @@ import (
 
 // DiffSuppressPayloads is a custom diff suppression function for the payloads attribute.
 func DiffSuppressPayloads(k, old, new string, d *schema.ResourceData) bool {
+	fmt.Printf("[DIFFSUPPRESS] Checking diff for key: %s\n", k)
 
-	if d.Get("payload_validate").(bool) {
-		log.Printf("Suppressing diff for key: %s", k)
-
-		processedOldPayload, err := processPayload(old, "Terraform state payload")
-		if err != nil {
-			log.Printf("Error processing old payload (Terraform state): %v", err)
-			return false
-		}
-
-		processedNewPayload, err := processPayload(new, "Jamf Pro server payload")
-		if err != nil {
-			log.Printf("Error processing new payload (Jamf Pro server): %v", err)
-			return false
-		}
-
-		oldHash := common.HashString(processedOldPayload)
-		newHash := common.HashString(processedNewPayload)
-
-		log.Printf("Old payload hash (Terraform state): %s\nOld payload (processed): %s", oldHash, processedOldPayload)
-		log.Printf("New payload hash (Jamf Pro server): %s\nNew payload (processed): %s", newHash, processedNewPayload)
-
-		return oldHash == newHash
-	} else {
-		return false //retain any drift on format (as we are not validating in this block)
+	processedOldPayload, err := processPayload(old, "Terraform state payload")
+	if err != nil {
+		fmt.Printf("[DIFFSUPPRESS] Error processing old payload (Terraform state): %v\n", err)
+		return false
 	}
 
+	processedNewPayload, err := processPayload(new, "Jamf Pro server payload")
+	if err != nil {
+		fmt.Printf("[DIFFSUPPRESS] Error processing new payload (Jamf Pro server): %v\n", err)
+		return false
+	}
+
+	oldHash := common.HashString(processedOldPayload)
+	newHash := common.HashString(processedNewPayload)
+
+	fmt.Printf("[DIFFSUPPRESS] Old payload hash: %s\n", oldHash)
+	fmt.Printf("[DIFFSUPPRESS] New payload hash: %s\n", newHash)
+
+	return oldHash == newHash
 }
 
-// processPayload processes the payload by comparing the old and new payloads. It removes specified fields and compares the hashes.
+// processPayload processes the payload by comparing the old and new payloads. It removes specified fields
+// and normalizes the base64 content, XML tags, empty strings, and HTML entities.
 func processPayload(payload string, source string) (string, error) {
-	log.Printf("Processing %s: %s", source, payload)
+	fmt.Printf("Processing %s: %s", source, payload)
 	fieldsToRemove := []string{"PayloadUUID", "PayloadIdentifier", "PayloadOrganization", "PayloadDisplayName"}
 	processedPayload, err := plist.ProcessConfigurationProfileForDiffSuppression(payload, fieldsToRemove)
 	if err != nil {
 		return "", err
 	}
-	log.Printf("Processed %s: %s", source, processedPayload)
+	fmt.Printf("Processed %s: %s", source, processedPayload)
 	return processedPayload, nil
 }

--- a/internal/resources/macosconfigurationprofilesplist/resource.go
+++ b/internal/resources/macosconfigurationprofilesplist/resource.go
@@ -159,6 +159,7 @@ func ResourceJamfProMacOSConfigurationProfilesPlist() *schema.Resource {
 						"self_service_icon_id": {
 							Type:        schema.TypeInt,
 							Optional:    true,
+							Default:     0,
 							Description: "Icon for policy to use in self-service",
 						},
 						"self_service_category": {


### PR DESCRIPTION
There was a logic error that resulted in the diff suppression only being triggered if 'payload_validate' was enabled. however we need this to run all of the time.