### PR TITLE
Draft: Add "Sensitive" attribute to JamfProActivationCode schema

### DIFF
--- a/internal/resources/activationcode/resource.go
+++ b/internal/resources/activationcode/resource.go
@@ -32,6 +32,7 @@ func ResourceJamfProActivationCode() *schema.Resource {
 			"code": {
 				Type:        schema.TypeString,
 				Required:    true,
+				Sensitive:   true,
 				Description: "The activation code.",
 			},
 		},


### PR DESCRIPTION
When importing a jamfpro_activation_code resource where the value of `code` is set to a sensitive variable, terraform will return the following on plan:

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # jamfpro_activation_code.this will be updated in-place
  # (imported from "activation_code_singleton")
  ~ resource "jamfpro_activation_code" "this" {
      # Warning: this attribute value will be marked as sensitive and will not
      # display in UI output after applying this change.
      ~ code              = (sensitive value)
        id                = "jamfpro_activation_code_singleton"
        organization_name = "Example Co."
    }

Plan: 1 to import, 0 to add, 1 to change, 0 to destroy.
```

TF code looks like this:

```
variable "activation_code" {
  type        = string
  description = "Jamf Pro activation code."
  sensitive   = true
}

import {
  to = jamfpro_activation_code.this
  id = jamfpro_activation_code_singleton
}

resource "jamfpro_activation_code" "this" {
  organization_name = "Example Co."
  code              = var.activation_code
}
```

`activation_code` variable is set in Terraform Cloud as a sensitive environment variable.

Ref: https://github.com/hashicorp/terraform/issues/26959