### PR TITLE
Package Resource Upload Verification Enhancement + helper centralization

### DIFF
--- a/examples/resources/jamfpro_computer_prestage_enrollments/resource.tf
+++ b/examples/resources/jamfpro_computer_prestage_enrollments/resource.tf
@@ -168,8 +168,8 @@ resource "jamfpro_computer_prestage_enrollment" "configured_example_1" {
   auto_advance_setup                      = false
   install_profiles_during_setup           = true
   prestage_installed_profile_ids          = [3114, jamfpro_macos_configuration_profile_plist.jamfpro_macos_configuration_profile_001.id]
-  custom_package_ids                      = [1, 2]        
-  custom_package_distribution_point_id    = "-2"     // "-1" - not used / "-2" - Cloud Distribution Point (Jamf Cloud) / "any other number" - Distribution Point ID
+  custom_package_ids                      = [1, 2]
+  custom_package_distribution_point_id    = "-2" // "-1" - not used / "-2" - Cloud Distribution Point (Jamf Cloud) / "any other number" - Distribution Point ID
   enable_recovery_lock                    = true
   recovery_lock_password_type             = "MANUAL" // "MANUAL" / "RANDOM"
   recovery_lock_password                  = "thing"

--- a/internal/resources/common/helpers.go
+++ b/internal/resources/common/helpers.go
@@ -7,9 +7,17 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
+	"io"
 	"log"
+	"mime"
+	"net/http"
+	"os"
+	"path/filepath"
 	"reflect"
+	"regexp"
 	"strconv"
+	"strings"
+	"time"
 )
 
 // HashString calculates the SHA-256 hash of a string and returns it as a hexadecimal string.
@@ -91,4 +99,109 @@ func getIDField(response interface{}) (any, error) {
 	}
 
 	return nil, fmt.Errorf("unsupported type")
+}
+
+// DownloadFile downloads a file from the given URL and saves it to a temporary file.
+// This is used for resources such as packages and icons where we want to reference a
+// web source.
+// If the Content-Disposition header is present in the response, it uses the filename
+// from the header. Otherwise, if no filename is provided in the headers, it uses the
+// final URL after any redirects to determine the filename. It also replaces any '%' characters
+// in the filename with '_'.
+func DownloadFile(url string) (string, error) {
+	tmpFile, err := os.CreateTemp("", "downloaded-*")
+	if err != nil {
+		return "", fmt.Errorf("failed to create temporary file: %v", err)
+	}
+	defer tmpFile.Close()
+
+	client := &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if len(via) >= 10 {
+				return fmt.Errorf("too many redirects when attempting to download file from %s", url)
+			}
+			return nil
+		},
+	}
+
+	resp, err := client.Get(url)
+	if err != nil {
+		return "", fmt.Errorf("failed to download file from %s: %v", url, err)
+	}
+	defer resp.Body.Close()
+
+	_, err = io.Copy(tmpFile, resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to write to temporary file: %v", err)
+	}
+
+	// Get the file name from the Content-Disposition header if available
+	_, params, err := mime.ParseMediaType(resp.Header.Get("Content-Disposition"))
+	if err == nil {
+		if filename, ok := params["filename"]; ok {
+			filename = strings.ReplaceAll(filename, "%", "_")
+			finalPath := filepath.Join(os.TempDir(), filename)
+			err = os.Rename(tmpFile.Name(), finalPath)
+			if err != nil {
+				return "", fmt.Errorf("failed to rename temporary file to final destination: %v", err)
+			}
+			log.Printf("[INFO] File downloaded to: %s", finalPath)
+			return finalPath, nil
+		}
+	}
+
+	finalURL := resp.Request.URL.String()
+	fileName := filepath.Base(finalURL)
+	fileName = strings.ReplaceAll(fileName, "%", "_")
+	finalPath := filepath.Join(os.TempDir(), fileName)
+	err = os.Rename(tmpFile.Name(), finalPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to rename temporary file to final destination: %v", err)
+	}
+	log.Printf("[INFO] File downloaded to: %s", finalPath)
+	return finalPath, nil
+}
+
+// CleanupDownloadedPackage handles the cleanup of downloaded package files from web sources.
+// It ensures files are only deleted if they were downloaded from HTTP(s) sources and are in the temporary directory.
+func CleanupDownloadedPackage(packageFileSource, localFilePath string) {
+	if !regexp.MustCompile(`^(http|https)://`).MatchString(packageFileSource) {
+		return
+	}
+
+	if !strings.HasPrefix(localFilePath, os.TempDir()) {
+		log.Printf("[WARN] Refusing to remove file '%s' as it's not in the temporary directory: timestamp=%s",
+			localFilePath, time.Now().UTC().Format(time.RFC3339))
+		return
+	}
+
+	if err := os.Remove(localFilePath); err != nil {
+		log.Printf("[WARN] Failed to remove downloaded package file '%s': %v: timestamp=%s",
+			localFilePath, err, time.Now().UTC().Format(time.RFC3339))
+	} else {
+		log.Printf("[INFO] Successfully removed downloaded package file '%s': timestamp=%s",
+			localFilePath, time.Now().UTC().Format(time.RFC3339))
+	}
+}
+
+// CleanupDownloadedIcon handles the cleanup of downloaded icon files from web sources.
+// It ensures files are only deleted if they were downloaded from HTTP(s) sources and are in the temporary directory.
+func CleanupDownloadedIcon(webSource, filePath string) {
+	if webSource == "" {
+		return
+	}
+
+	if !strings.HasPrefix(filePath, os.TempDir()) {
+		log.Printf("[WARN] Refusing to remove file '%s' as it's not in the temporary directory: timestamp=%s",
+			filePath, time.Now().UTC().Format(time.RFC3339))
+		return
+	}
+
+	if err := os.Remove(filePath); err != nil {
+		log.Printf("[WARN] Failed to remove downloaded icon file '%s': %v: timestamp=%s",
+			filePath, err, time.Now().UTC().Format(time.RFC3339))
+	} else {
+		log.Printf("[INFO] Successfully removed downloaded icon file '%s': timestamp=%s",
+			filePath, time.Now().UTC().Format(time.RFC3339))
+	}
 }

--- a/internal/resources/common/redeployment.go
+++ b/internal/resources/common/redeployment.go
@@ -4,13 +4,6 @@
 package common
 
 import (
-	"fmt"
-	"io"
-	"log"
-	"mime"
-	"net/http"
-	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -35,65 +28,4 @@ func HandleResourceNotFoundError(err error, d *schema.ResourceData, cleanup bool
 
 	return diags
 
-}
-
-// DownloadFile downloads a file from the given URL and saves it to a temporary file.
-// This is used for resources such as packages and icons where we want to reference a
-// web source.
-// If the Content-Disposition header is present in the response, it uses the filename
-// from the header. Otherwise, if no filename is provided in the headers, it uses the
-// final URL after any redirects to determine the filename. It also replaces any '%' characters
-// in the filename with '_'.
-func DownloadFile(url string) (string, error) {
-	tmpFile, err := os.CreateTemp("", "downloaded-*")
-	if err != nil {
-		return "", fmt.Errorf("failed to create temporary file: %v", err)
-	}
-	defer tmpFile.Close()
-
-	client := &http.Client{
-		CheckRedirect: func(req *http.Request, via []*http.Request) error {
-			if len(via) >= 10 {
-				return fmt.Errorf("too many redirects when attempting to download file from %s", url)
-			}
-			return nil
-		},
-	}
-
-	resp, err := client.Get(url)
-	if err != nil {
-		return "", fmt.Errorf("failed to download file from %s: %v", url, err)
-	}
-	defer resp.Body.Close()
-
-	_, err = io.Copy(tmpFile, resp.Body)
-	if err != nil {
-		return "", fmt.Errorf("failed to write to temporary file: %v", err)
-	}
-
-	// Get the file name from the Content-Disposition header if available
-	_, params, err := mime.ParseMediaType(resp.Header.Get("Content-Disposition"))
-	if err == nil {
-		if filename, ok := params["filename"]; ok {
-			filename = strings.ReplaceAll(filename, "%", "_")
-			finalPath := filepath.Join(os.TempDir(), filename)
-			err = os.Rename(tmpFile.Name(), finalPath)
-			if err != nil {
-				return "", fmt.Errorf("failed to rename temporary file to final destination: %v", err)
-			}
-			log.Printf("[INFO] File downloaded to: %s", finalPath)
-			return finalPath, nil
-		}
-	}
-
-	finalURL := resp.Request.URL.String()
-	fileName := filepath.Base(finalURL)
-	fileName = strings.ReplaceAll(fileName, "%", "_")
-	finalPath := filepath.Join(os.TempDir(), fileName)
-	err = os.Rename(tmpFile.Name(), finalPath)
-	if err != nil {
-		return "", fmt.Errorf("failed to rename temporary file to final destination: %v", err)
-	}
-	log.Printf("[INFO] File downloaded to: %s", finalPath)
-	return finalPath, nil
 }

--- a/internal/resources/icons/crud.go
+++ b/internal/resources/icons/crud.go
@@ -3,11 +3,7 @@ package icons
 import (
 	"context"
 	"fmt"
-	"log"
-	"os"
 	"strconv"
-	"strings"
-	"time"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
 	"github.com/deploymenttheory/terraform-provider-jamfpro/internal/resources/common"
@@ -43,21 +39,7 @@ func create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.
 	d.SetId(fmt.Sprintf("%d", uploadResponse.ID))
 
 	// Only clean up if we downloaded from web source and verify the path is what we expect
-	if webSource := d.Get("icon_file_web_source").(string); webSource != "" {
-		if !strings.HasPrefix(filePath, os.TempDir()) {
-			log.Printf("[WARN] Refusing to remove file '%s' as it's not in the temporary directory: timestamp=%s",
-				filePath, time.Now().UTC().Format(time.RFC3339))
-			return diags
-		}
-
-		if err := os.Remove(filePath); err != nil {
-			log.Printf("[WARN] Failed to remove downloaded icon file '%s': %v: timestamp=%s",
-				filePath, err, time.Now().UTC().Format(time.RFC3339))
-		} else {
-			log.Printf("[INFO] Successfully removed downloaded icon file '%s': timestamp=%s",
-				filePath, time.Now().UTC().Format(time.RFC3339))
-		}
-	}
+	common.CleanupDownloadedIcon(d.Get("icon_file_web_source").(string), filePath)
 
 	return append(diags, readNoCleanup(ctx, d, meta)...)
 }
@@ -127,21 +109,7 @@ func update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.
 		}
 
 		// Only clean up if we downloaded from web source and verify the path is what we expect
-		if webSource := d.Get("icon_file_web_source").(string); webSource != "" {
-			if !strings.HasPrefix(filePath, os.TempDir()) {
-				log.Printf("[WARN] Refusing to remove file '%s' as it's not in the temporary directory: timestamp=%s",
-					filePath, time.Now().UTC().Format(time.RFC3339))
-				return diags
-			}
-
-			if err := os.Remove(filePath); err != nil {
-				log.Printf("[WARN] Failed to remove downloaded icon file '%s': %v: timestamp=%s",
-					filePath, err, time.Now().UTC().Format(time.RFC3339))
-			} else {
-				log.Printf("[INFO] Successfully removed downloaded icon file '%s': timestamp=%s",
-					filePath, time.Now().UTC().Format(time.RFC3339))
-			}
-		}
+		common.CleanupDownloadedIcon(d.Get("icon_file_web_source").(string), filePath)
 	}
 
 	return append(diags, readNoCleanup(ctx, d, meta)...)

--- a/internal/resources/macosconfigurationprofilesplist/constructor.go
+++ b/internal/resources/macosconfigurationprofilesplist/constructor.go
@@ -176,6 +176,7 @@ func constructMacOSConfigurationProfileSubsetSelfService(data map[string]interfa
 		SelfServiceDescription:      data["self_service_description"].(string),
 		ForceUsersToViewDescription: data["force_users_to_view_description"].(bool),
 		FeatureOnMainPage:           data["feature_on_main_page"].(bool),
+		Notification:                data["notification"].(string),
 		NotificationSubject:         data["notification_subject"].(string),
 		NotificationMessage:         data["notification_message"].(string),
 	}

--- a/internal/resources/packages/crud.go
+++ b/internal/resources/packages/crud.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log"
 	"path/filepath"
-	"time"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
 	"github.com/deploymenttheory/terraform-provider-jamfpro/internal/resources/common"
@@ -15,70 +14,61 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-// create is responsible for creating a new Jamf Pro Package in the remote system.
-// The function:
+// create handles the creation of a Jamf Pro package resource:
 // 1. Constructs the attribute data using the provided Terraform configuration.
-// 2. Calls the API to create the package metadata in jamfpro.
-// 3. Uploads the package file to the Jamf Pro server.
-// 4. Verifes upload hash
-// 5. Sets the ID of the created package in the Terraform state.
-// 6. Perform cleanup of downloaded package if it was from an HTTP(s) source
-// 7. Reads the created package to ensure the Terraform state is up-to-date.
+// 2. Calculates initial SHA3-512 hash of the package file.
+// 3. Calls the API to create the package metadata in Jamf Pro.
+// 4. Uploads the package file to the Jamf Pro server.
+// 5. Verifies the uploaded package hash matches the initial hash.
+// 6. If verification fails, deletes the package from Jamf Pro.
+// 7. If verification succeeds, sets the package ID in Terraform state.
+// 8. Performs cleanup of downloaded package if it was from an HTTP(s) source.
+// 9. Reads the created package to ensure the Terraform state is up-to-date.
 func create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*jamfpro.Client)
 	var diags diag.Diagnostics
+	var packageID string
 
 	resource, localFilePath, err := construct(d)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("failed to construct Jamf Pro Package: %v", err))
 	}
 
-	// Set the filename in the resource based on the local file path
 	resource.FileName = filepath.Base(localFilePath)
 
-	err = retry.RetryContext(ctx, d.Timeout(schema.TimeoutCreate), func() *retry.RetryError {
-		initialHash, err := jamfpro.CalculateSHA3_512(localFilePath)
-		if err != nil {
-			return retry.NonRetryableError(fmt.Errorf("failed to calculate SHA3-512: %v", err))
-		}
+	initialHash, err := jamfpro.CalculateSHA3_512(localFilePath)
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("failed to calculate SHA3-512: %v", err))
+	}
 
+	err = retry.RetryContext(ctx, d.Timeout(schema.TimeoutCreate), func() *retry.RetryError {
 		creationResponse, err := client.CreatePackage(*resource)
 		if err != nil {
 			return retry.RetryableError(fmt.Errorf("failed to create package metadata in Jamf Pro: %v", err))
 		}
 
-		log.Printf("[INFO] Jamf Pro package metadata created successfully with package ID: %s", creationResponse.ID)
+		packageID = creationResponse.ID
+		log.Printf("[INFO] Jamf Pro package metadata created successfully with package ID: %s", packageID)
 
-		_, err = client.UploadPackage(creationResponse.ID, []string{localFilePath})
+		_, err = client.UploadPackage(packageID, []string{localFilePath})
 		if err != nil {
 			log.Printf("[ERROR] Failed to upload package file '%s': %v", resource.FileName, err)
 			return retry.NonRetryableError(fmt.Errorf("failed to upload package file: %v", err))
 		}
 
 		log.Printf("[INFO] Package %s file uploaded successfully", resource.FileName)
-
-		// Wait for JCDS to process the upload
-		time.Sleep(3 * time.Second)
-
-		uploadedPackage, err := client.GetPackageByID(creationResponse.ID)
-		if err != nil {
-			return retry.RetryableError(fmt.Errorf("failed to verify uploaded package: %v", err))
-		}
-
-		if uploadedPackage.HashType != "SHA3_512" || uploadedPackage.HashValue != initialHash {
-			return retry.NonRetryableError(fmt.Errorf("hash verification failed: initial=%s, uploaded=%s (type: %s)",
-				initialHash, uploadedPackage.HashValue, uploadedPackage.HashType))
-		}
-
-		log.Printf("[INFO] Package %s SHA3-512 verification successful with hash: %s", resource.FileName, uploadedPackage.HashValue)
-		d.SetId(creationResponse.ID)
-
 		return nil
 	})
-
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("failed to create and upload Jamf Pro Package '%s': %v", resource.PackageName, err))
 	}
+
+	if err := verifyPackageUpload(ctx, client, packageID, resource.FileName, initialHash,
+		d.Timeout(schema.TimeoutCreate)); err != nil {
+		return diag.FromErr(fmt.Errorf("failed to verify Jamf Pro Package '%s': %v", resource.PackageName, err))
+	}
+
+	d.SetId(packageID)
 
 	common.CleanupDownloadedPackage(d.Get("package_file_source").(string), localFilePath)
 
@@ -119,15 +109,16 @@ func readNoCleanup(ctx context.Context, d *schema.ResourceData, meta interface{}
 	return read(ctx, d, meta, false)
 }
 
-// update is responsible for updating an existing Jamf Pro Package on the remote system.
-// The function:
-// 1. Constructs the attribute data using the provided Terraform configuration.
-// 2. calculates the SHA3-512 hash of the local file.
-// 3. Calls the API to update the package metadata in jamfpro.
-// 4. Uploads the package file to the Jamf Pro server.
-// 5. Verifes upload hash
-// 6. Reads the updated package to ensure the Terraform state is up-to-date.
-// 7. Perform cleanup of downloaded package if it was from an HTTP(s) source
+// update handles the updating of a Jamf Pro package resource:
+//  1. Constructs the updated attribute data from the Terraform configuration.
+//  2. Calculates SHA3-512 hash of the new package file.
+//  3. Updates the package metadata in Jamf Pro.
+//  4. If the file hash differs from current:
+//     a. Uploads the new package file.
+//     b. Verifies the uploaded package hash matches.
+//     c. If verification fails, attempts to revert metadata changes.
+//  5. Performs cleanup of downloaded package if it was from an HTTP(s) source.
+//  6. Reads the updated package to ensure the Terraform state is up-to-date.
 func update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*jamfpro.Client)
 	var diags diag.Diagnostics
@@ -144,43 +135,53 @@ func update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.
 	}
 
 	err = retry.RetryContext(ctx, d.Timeout(schema.TimeoutUpdate), func() *retry.RetryError {
-		_, apiErr := client.UpdatePackageByID(resourceID, *resource)
-		if apiErr != nil {
-			return retry.RetryableError(apiErr)
+		_, err := client.UpdatePackageByID(resourceID, *resource)
+		if err != nil {
+			return retry.RetryableError(fmt.Errorf("failed to update package metadata: %v", err))
 		}
 
-		currentPackage, apiErr := client.GetPackageByID(resourceID)
-		if apiErr != nil {
-			return retry.RetryableError(fmt.Errorf("failed to get current package state: %v", apiErr))
+		currentPackage, err := client.GetPackageByID(resourceID)
+		if err != nil {
+			return retry.RetryableError(fmt.Errorf("failed to get current package state: %v", err))
 		}
 
-		if newFileHash != currentPackage.HashValue {
-			_, apiErr = client.UploadPackage(resourceID, []string{localFilePath})
-			if apiErr != nil {
-				return retry.RetryableError(fmt.Errorf("failed to upload package file: %v", apiErr))
-			}
-
-			time.Sleep(5 * time.Second)
-
-			uploadedPackage, apiErr := client.GetPackageByID(resourceID)
-			if apiErr != nil {
-				return retry.RetryableError(fmt.Errorf("failed to verify uploaded package: %v", apiErr))
-			}
-
-			if uploadedPackage.HashValue != newFileHash {
-				return retry.NonRetryableError(fmt.Errorf("hash verification failed after upload: expected=%s, got=%s",
-					newFileHash, uploadedPackage.HashValue))
-			}
-
-			log.Printf("[INFO] Package %s SHA3-512 verification successful with hash: %s",
-				filepath.Base(localFilePath), uploadedPackage.HashValue)
+		if newFileHash == currentPackage.HashValue {
+			log.Printf("[INFO] Package file unchanged, skipping upload")
+			return nil
 		}
 
 		return nil
 	})
 
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("failed to update Jamf Pro Package '%s' (ID: %s): %v", resource.PackageName, resourceID, err))
+		return diag.FromErr(fmt.Errorf("failed to update Jamf Pro Package metadata '%s' (ID: %s): %v",
+			resource.PackageName, resourceID, err))
+	}
+
+	currentPackage, err := client.GetPackageByID(resourceID)
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("failed to get package state: %v", err))
+	}
+
+	if newFileHash != currentPackage.HashValue {
+		err = retry.RetryContext(ctx, d.Timeout(schema.TimeoutUpdate), func() *retry.RetryError {
+			_, err := client.UploadPackage(resourceID, []string{localFilePath})
+			if err != nil {
+				return retry.RetryableError(fmt.Errorf("failed to upload package file: %v", err))
+			}
+
+			log.Printf("[INFO] Package file uploaded successfully")
+			return nil
+		})
+
+		if err != nil {
+			return diag.FromErr(fmt.Errorf("failed to upload new package file: %v", err))
+		}
+
+		if err := verifyPackageUpload(ctx, client, resourceID, resource.FileName, newFileHash,
+			d.Timeout(schema.TimeoutUpdate)); err != nil {
+			return diag.FromErr(fmt.Errorf("failed to verify updated package file: %v", err))
+		}
 	}
 
 	common.CleanupDownloadedPackage(d.Get("package_file_source").(string), localFilePath)

--- a/internal/resources/packages/helpers.go
+++ b/internal/resources/packages/helpers.go
@@ -1,0 +1,63 @@
+// packages_helpers.go
+package packages
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+)
+
+// verifyPackageUpload attempts to verify a package upload by comparing SHA3-512 hashes.
+// The function will:
+// 1. Continuously retry while the server calculates the hash (empty hash value)
+// 2. Once a hash value is present, perform a one-time verification against the expected hash
+// 3. If verification fails or encounters an error, attempt to delete the package
+// The function returns an error if verification fails, cleanup fails, or any other error occurs.
+func verifyPackageUpload(ctx context.Context, client *jamfpro.Client, packageID string, fileName string, expectedHash string, timeout time.Duration) error {
+	err := retry.RetryContext(ctx, timeout, func() *retry.RetryError {
+		uploadedPackage, err := client.GetPackageByID(packageID)
+		if err != nil {
+			return retry.RetryableError(fmt.Errorf("failed to verify uploaded package: %v", err))
+		}
+
+		if uploadedPackage.HashValue == "" {
+			return retry.RetryableError(fmt.Errorf("waiting for package hash calculation to complete"))
+		}
+
+		if uploadedPackage.HashType != "SHA3_512" || uploadedPackage.HashValue != expectedHash {
+			return retry.NonRetryableError(fmt.Errorf("package hash verification failed: expected=%s, got=%s (type: %s)",
+				expectedHash, uploadedPackage.HashValue, uploadedPackage.HashType))
+		}
+
+		log.Printf("[INFO] Package %s SHA3-512 verification successful with hash: %s",
+			fileName, uploadedPackage.HashValue)
+		return nil
+	})
+
+	if err != nil {
+		cleanupErr := retry.RetryContext(ctx, timeout, func() *retry.RetryError {
+			if packageID == "" {
+				return nil
+			}
+
+			if err := client.DeletePackageByID(packageID); err != nil {
+				return retry.RetryableError(fmt.Errorf("failed to clean up package %s: %v", packageID, err))
+			}
+
+			log.Printf("[INFO] Successfully cleaned up package %s after verification failure", packageID)
+			return nil
+		})
+
+		if cleanupErr != nil {
+			log.Printf("[WARN] Failed to clean up package %s after verification failure: %v", packageID, cleanupErr)
+		}
+
+		return fmt.Errorf("failed to verify package upload: %v", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
Summary
Unified and improved the package upload verification logic across create and update operations. The changes implement a refined verification process that properly handles server-side hash calculation delays and adds new consistent cleanup of failed / corrupted package uploads.

Unified Verification Logic
- Consolidated duplicate verification code from create/update operations into a single helper function
- Removed differentiation between create/update verification behaviour
- Consistent package cleanup on any verification failure

Improved Hash Verification Flow
- Added explicit handling for waiting on server-side hash calculation
- Retries only while hash value is empty/null
- One-time verification once hash value is present
- Non-retryable failure if hash mismatch detected

Centralised package removal function and moved it to a helper function location within the common package 

successfully tested with:

- 3 sequential http(s) and local file package source package creates
- 3 parallel http(s) and local file package source package creates
- can perform update of package metadata only and package won't reupload
- can perform update of package  +metadata only and both will be updated