### PR TITLE
fix: refactor of state migration logic for Payload/UserInteraction

### DIFF
--- a/internal/resources/policies/resource.go
+++ b/internal/resources/policies/resource.go
@@ -29,7 +29,7 @@ func ResourceJamfProPolicies() *schema.Resource {
 		SchemaVersion: 1,
 		StateUpgraders: []schema.StateUpgrader{
 			{
-				Type:    resourcePolicyUserInteractionV0().CoreConfigSchema().ImpliedType(),
+				Type:    resourcePolicyV0().CoreConfigSchema().ImpliedType(),
 				Upgrade: upgradePolicyUserInteractionV0toV1,
 				Version: 0,
 			},

--- a/internal/resources/policies/state_migration.go
+++ b/internal/resources/policies/state_migration.go
@@ -6,34 +6,72 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-// resourcePolicyUserInteractionV0 defines the v0 schema for the user interaction block in the policy resource.
-func resourcePolicyUserInteractionV0() *schema.Resource {
+// resourcePolicyV0 defines the v0 schema for the user interaction block in the policy resource.
+func resourcePolicyV0() *schema.Resource {
 	return &schema.Resource{
 		Schema: map[string]*schema.Schema{
-			"message_start":            {Type: schema.TypeString, Optional: true},
-			"allow_user_to_defer":      {Type: schema.TypeBool, Optional: true, Default: false},
-			"allow_deferral_until_utc": {Type: schema.TypeString, Optional: true},
-			"allow_deferral_minutes":   {Type: schema.TypeInt, Optional: true, Default: 0},
-			"message_finish":           {Type: schema.TypeString, Optional: true},
+			"payloads": {
+				Type:     schema.TypeList,
+				Required: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"user_interaction": {
+							Type:     schema.TypeList,
+							MaxItems: 1,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"message_start": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"allow_user_to_defer": { // Old field name
+										Type:     schema.TypeBool,
+										Optional: true,
+									},
+									"allow_deferral_until_utc": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"allow_deferral_minutes": {
+										Type:     schema.TypeInt,
+										Optional: true,
+									},
+									"message_finish": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 		},
 	}
 }
 
-// Migration function to handle the upgrade from V0 to V1
-// copies the existing fields and updates the allow_user_to_defer field to allow_users_to_defer
 func upgradePolicyUserInteractionV0toV1(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
-	newState := make(map[string]interface{})
+	if payloads, ok := rawState["payloads"].([]interface{}); ok && len(payloads) > 0 {
+		payload := payloads[0].(map[string]interface{})
+		if userInteractions, ok := payload["user_interaction"].([]interface{}); ok && len(userInteractions) > 0 {
+			userInteraction := userInteractions[0].(map[string]interface{})
 
-	newState["message_start"] = rawState["message_start"]
-	newState["allow_deferral_until_utc"] = rawState["allow_deferral_until_utc"]
-	newState["allow_deferral_minutes"] = rawState["allow_deferral_minutes"]
-	newState["message_finish"] = rawState["message_finish"]
+			// Create a new interaction block with the new field name
+			newInteraction := map[string]interface{}{
+				"message_start":            userInteraction["message_start"],
+				"allow_users_to_defer":     userInteraction["allow_user_to_defer"],
+				"allow_deferral_until_utc": userInteraction["allow_deferral_until_utc"],
+				"allow_deferral_minutes":   userInteraction["allow_deferral_minutes"],
+				"message_finish":           userInteraction["message_finish"],
+			}
 
-	if deferVal, ok := rawState["allow_user_to_defer"]; ok {
-		newState["allow_users_to_defer"] = deferVal
-	} else {
-		newState["allow_users_to_defer"] = false
+			userInteractions[0] = newInteraction
+			payload["user_interaction"] = userInteractions
+			payloads[0] = payload
+			rawState["payloads"] = payloads
+		}
 	}
-
-	return newState, nil
+	return rawState, nil
 }

--- a/internal/resources/policies/state_payloads.go
+++ b/internal/resources/policies/state_payloads.go
@@ -321,7 +321,7 @@ func prepStatePayloadFilesProcesses(out *[]map[string]interface{}, resp *jamfpro
 func prepStatePayloadUserInteraction(out *[]map[string]interface{}, resp *jamfpro.ResourcePolicy) {
 	defaults := map[string]interface{}{
 		"message_start":            "",
-		"allow_user_to_defer":      false,
+		"allow_users_to_defer":     false,
 		"allow_deferral_until_utc": "",
 		"allow_deferral_minutes":   0,
 		"message_finish":           "",
@@ -329,7 +329,7 @@ func prepStatePayloadUserInteraction(out *[]map[string]interface{}, resp *jamfpr
 
 	userInteractionBlock := map[string]interface{}{
 		"message_start":            resp.UserInteraction.MessageStart,
-		"allow_user_to_defer":      resp.UserInteraction.AllowUsersToDefer,
+		"allow_users_to_defer":     resp.UserInteraction.AllowUsersToDefer,
 		"allow_deferral_until_utc": resp.UserInteraction.AllowDeferralUntilUtc,
 		"allow_deferral_minutes":   resp.UserInteraction.AllowDeferralMinutes,
 		"message_finish":           resp.UserInteraction.MessageFinish,


### PR DESCRIPTION
previous iteration would some times cause tf to attempt a resource create. This fix now consistently performs a change to the existing resource state.