### PR TITLE
fix: macos plist handling for payloadUUID update operation

### DIFF
--- a/internal/resources/filesharedistributionpoints/crud.go
+++ b/internal/resources/filesharedistributionpoints/crud.go
@@ -13,13 +13,8 @@ const (
 	JamfProResourceDistributionPoint = "Distribution Point"
 )
 
-// Create requires a mutex need to lock Create requests during parallel runs
-// var mu sync.Mutex
-
 // create is responsible for creating a new file share
 func create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	// mu.Lock()
-	// defer mu.Unlock()
 	return common.Create(
 		ctx,
 		d,
@@ -64,7 +59,7 @@ func update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.
 	)
 }
 
-// deleteis responsible for deleting a Jamf Pro file share distribution point from the remote system.
+// delete is responsible for deleting a Jamf Pro file share distribution point from the remote system.
 func delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	return common.Delete(
 		ctx,

--- a/internal/resources/macosconfigurationprofilesplist/crud.go
+++ b/internal/resources/macosconfigurationprofilesplist/crud.go
@@ -1,39 +1,28 @@
 package macosconfigurationprofilesplist
 
 import (
-	"bytes"
 	"context"
 	"fmt"
-	"html"
 	"strconv"
-	"strings"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
 	"github.com/deploymenttheory/terraform-provider-jamfpro/internal/resources/common"
-	pliststruct "github.com/deploymenttheory/terraform-provider-jamfpro/internal/resources/common/configurationprofiles/plist"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"howett.net/plist"
 )
 
-// Create requires a mutex need to lock Create requests during parallel runs
-// var mu sync.Mutex
-
-// resourceJamfProMacOSConfigurationProfilesPlistCreate is responsible for creating a new Jamf Pro macOS Configuration Profile in the remote system.
+// create is responsible for creating a new Jamf Pro macOS Configuration Profile in the remote system.
 // The function:
 // 1. Constructs the attribute data using the provided Terraform configuration.
 // 2. Calls the API to create the attribute in Jamf Pro.
 // 3. Updates the Terraform state with the ID of the newly created attribute.
 // 4. Initiates a read operation to synchronize the Terraform state with the actual state in Jamf Pro.
-func resourceJamfProMacOSConfigurationProfilesPlistCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*jamfpro.Client)
 	var diags diag.Diagnostics
 
-	// mu.Lock()
-	// defer mu.Unlock()
-
-	resource, err := constructJamfProMacOSConfigurationProfilePlist(d)
+	resource, err := constructJamfProMacOSConfigurationProfilePlist(d, "create", meta)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("failed to construct Jamf Pro macOS Configuration Profile: %v", err))
 	}
@@ -54,15 +43,15 @@ func resourceJamfProMacOSConfigurationProfilesPlistCreate(ctx context.Context, d
 
 	d.SetId(strconv.Itoa(creationResponse.ID))
 
-	return append(diags, resourceJamfProMacOSConfigurationProfilesPlistReadNoCleanup(ctx, d, meta)...)
+	return append(diags, readNoCleanup(ctx, d, meta)...)
 }
 
-// resourceJamfProMacOSConfigurationProfilesPlistRead is responsible for reading the current state of a Jamf Pro config profile Resource from the remote system.
+// read is responsible for reading the current state of a Jamf Pro config profile Resource from the remote system.
 // The function:
 // 1. Fetches the attribute's current state using its ID. If it fails then obtain attribute's current state using its Name.
 // 2. Updates the Terraform state with the fetched data to ensure it accurately reflects the current state in Jamf Pro.
 // 3. Handles any discrepancies, such as the attribute being deleted outside of Terraform, to keep the Terraform state synchronized.
-func resourceJamfProMacOSConfigurationProfilesPlistRead(ctx context.Context, d *schema.ResourceData, meta interface{}, cleanup bool) diag.Diagnostics {
+func read(ctx context.Context, d *schema.ResourceData, meta interface{}, cleanup bool) diag.Diagnostics {
 	client := meta.(*jamfpro.Client)
 	resourceID := d.Id()
 	var diags diag.Diagnostics
@@ -84,82 +73,26 @@ func resourceJamfProMacOSConfigurationProfilesPlistRead(ctx context.Context, d *
 	return append(diags, updateState(d, response)...)
 }
 
-// resourceJamfProMacOSConfigurationProfilesPlistReadWithCleanup reads the resource with cleanup enabled
-func resourceJamfProMacOSConfigurationProfilesPlistReadWithCleanup(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	return resourceJamfProMacOSConfigurationProfilesPlistRead(ctx, d, meta, true)
+// readWithCleanup reads the resource with cleanup enabled
+func readWithCleanup(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return read(ctx, d, meta, true)
 }
 
-// resourceJamfProMacOSConfigurationProfilesPlistReadNoCleanup reads the resource with cleanup disabled
-func resourceJamfProMacOSConfigurationProfilesPlistReadNoCleanup(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	return resourceJamfProMacOSConfigurationProfilesPlistRead(ctx, d, meta, false)
+// readNoCleanup reads the resource with cleanup disabled
+func readNoCleanup(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return read(ctx, d, meta, false)
 }
 
-// resourceJamfProMacOSConfigurationProfilesPlistUpdate is responsible for updating an existing Jamf Pro config profile on the remote system.
-func resourceJamfProMacOSConfigurationProfilesPlistUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+// update is responsible for updating an existing Jamf Pro config profile on the remote system.
+func update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*jamfpro.Client)
 	var diags diag.Diagnostics
 	resourceID := d.Id()
 
-	// Get existing profile to get current UUIDs
-	existingProfile, err := client.GetMacOSConfigurationProfileByID(resourceID)
-	if err != nil {
-		return diag.FromErr(fmt.Errorf("failed to get existing profile: %v", err))
-	}
-
-	// Extract existing UUIDs map from existing profile
-	existingUUIDs := make(map[string]string)
-	unescapedExistingPayload := html.UnescapeString(existingProfile.General.Payloads)
-	var existingConfig pliststruct.ConfigurationProfile
-	if err := plist.NewDecoder(strings.NewReader(unescapedExistingPayload)).Decode(&existingConfig); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to decode existing plist: %v", err))
-	}
-
-	// Store root UUID
-	existingUUIDs["root"] = existingConfig.PayloadUUID
-
-	// Store PayloadContent UUIDs
-	for _, content := range existingConfig.PayloadContent {
-		existingUUIDs[content.PayloadDisplayName] = content.PayloadUUID
-	}
-
-	// Construct new profile
-	resource, err := constructJamfProMacOSConfigurationProfilePlist(d)
+	resource, err := constructJamfProMacOSConfigurationProfilePlist(d, "update", meta)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("failed to construct profile for update: %v", err))
 	}
-
-	// Unescape the XML payload
-	unescapedPayload := html.UnescapeString(resource.General.Payloads)
-
-	// Parse new payload
-	var newConfig pliststruct.ConfigurationProfile
-	if err := plist.NewDecoder(strings.NewReader(unescapedPayload)).Decode(&newConfig); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to decode new plist: %v", err))
-	}
-
-	// Update root UUID
-	if rootUUID, exists := existingUUIDs["root"]; exists {
-		newConfig.PayloadUUID = rootUUID
-	}
-
-	// Update PayloadContent UUIDs
-	for i, content := range newConfig.PayloadContent {
-		if uuid, exists := existingUUIDs[content.PayloadDisplayName]; exists {
-			newConfig.PayloadContent[i].PayloadUUID = uuid
-			newConfig.PayloadContent[i].PayloadIdentifier = uuid
-		}
-	}
-
-	// Encode back to plist
-	var buf bytes.Buffer
-	encoder := plist.NewEncoder(&buf)
-	encoder.Indent("    ")
-	if err := encoder.Encode(newConfig); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to encode updated plist: %v", err))
-	}
-
-	// Escape special characters for XML
-	resource.General.Payloads = html.EscapeString(buf.String())
 
 	err = retry.RetryContext(ctx, d.Timeout(schema.TimeoutUpdate), func() *retry.RetryError {
 		_, apiErr := client.UpdateMacOSConfigurationProfileByID(resourceID, resource)
@@ -173,11 +106,11 @@ func resourceJamfProMacOSConfigurationProfilesPlistUpdate(ctx context.Context, d
 		return diag.FromErr(fmt.Errorf("failed to update profile '%s' (ID: %s): %v", resource.General.Name, resourceID, err))
 	}
 
-	return append(diags, resourceJamfProMacOSConfigurationProfilesPlistReadNoCleanup(ctx, d, meta)...)
+	return append(diags, readNoCleanup(ctx, d, meta)...)
 }
 
-// resourceJamfProMacOSConfigurationProfilesPlistDelete is responsible for deleting a Jamf Pro config profile.
-func resourceJamfProMacOSConfigurationProfilesPlistDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+// delete is responsible for deleting a Jamf Pro config profile.
+func delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*jamfpro.Client)
 	var diags diag.Diagnostics
 	resourceID := d.Id()

--- a/internal/resources/macosconfigurationprofilesplist/helpers.go
+++ b/internal/resources/macosconfigurationprofilesplist/helpers.go
@@ -44,3 +44,58 @@ func FixDuplicateNotificationKey(resp *jamfpro.ResourceMacOSConfigurationProfile
 	// Return default value if no valid boolean value is found
 	return false, nil
 }
+
+// extractUUIDs recursively extracts config profile UUIDs from a plist structure
+// and stores them in a map by PayloadDisplayName.
+func extractUUIDs(data interface{}, uuidMap map[string]string) {
+	switch v := data.(type) {
+	case map[string]interface{}:
+		displayName, hasDisplayName := v["PayloadDisplayName"].(string)
+		uuid, hasUUID := v["PayloadUUID"].(string)
+
+		if hasDisplayName && hasUUID {
+			uuidMap[displayName] = uuid
+		} else if hasUUID {
+			// For root level, use special key
+			uuidMap["root"] = uuid
+		}
+
+		// Recursively process all values
+		for _, val := range v {
+			extractUUIDs(val, uuidMap)
+		}
+	case []interface{}:
+		for _, item := range v {
+			extractUUIDs(item, uuidMap)
+		}
+	}
+}
+
+// updateUUIDs recursively updates config profile UUIDs in a
+// plist structure
+func updateUUIDs(data interface{}, uuidMap map[string]string) {
+	switch v := data.(type) {
+	case map[string]interface{}:
+		displayName, hasDisplayName := v["PayloadDisplayName"].(string)
+		if hasDisplayName {
+			if uuid, exists := uuidMap[displayName]; exists {
+				v["PayloadUUID"] = uuid
+				v["PayloadIdentifier"] = uuid // Also update identifier
+			}
+		} else {
+			// For root level
+			if uuid, exists := uuidMap["root"]; exists {
+				v["PayloadUUID"] = uuid
+			}
+		}
+
+		// Recursively process all values
+		for _, val := range v {
+			updateUUIDs(val, uuidMap)
+		}
+	case []interface{}:
+		for _, item := range v {
+			updateUUIDs(item, uuidMap)
+		}
+	}
+}

--- a/internal/resources/macosconfigurationprofilesplist/resource.go
+++ b/internal/resources/macosconfigurationprofilesplist/resource.go
@@ -13,10 +13,10 @@ import (
 // resourceJamfProMacOSConfigurationProfilesPlist defines the schema and CRUD operations for managing Jamf Pro macOS Configuration Profiles in Terraform.
 func ResourceJamfProMacOSConfigurationProfilesPlist() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceJamfProMacOSConfigurationProfilesPlistCreate,
-		ReadContext:   resourceJamfProMacOSConfigurationProfilesPlistReadWithCleanup,
-		UpdateContext: resourceJamfProMacOSConfigurationProfilesPlistUpdate,
-		DeleteContext: resourceJamfProMacOSConfigurationProfilesPlistDelete,
+		CreateContext: create,
+		ReadContext:   readWithCleanup,
+		UpdateContext: update,
+		DeleteContext: delete,
 		CustomizeDiff: mainCustomDiffFunc,
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(120 * time.Second),

--- a/internal/resources/macosconfigurationprofilesplist/state.go
+++ b/internal/resources/macosconfigurationprofilesplist/state.go
@@ -276,18 +276,6 @@ func setSelfService(selfService jamfpro.MacOSConfigurationProfileSubsetSelfServi
 		selfServiceBlock["notification"] = correctNotifValue
 	}
 
-	// Handle self service icon
-	if selfService.SelfServiceIcon.ID != 0 {
-		selfServiceBlock["self_service_icon"] = []interface{}{
-			map[string]interface{}{
-				"id":       selfService.SelfServiceIcon.ID,
-				"uri":      selfService.SelfServiceIcon.URI,
-				"data":     selfService.SelfServiceIcon.Data,
-				"filename": selfService.SelfServiceIcon.Filename,
-			},
-		}
-	}
-
 	// Handle self service categories
 	if len(selfService.SelfServiceCategories) > 0 {
 		categories := make([]interface{}, len(selfService.SelfServiceCategories))
@@ -305,7 +293,7 @@ func setSelfService(selfService jamfpro.MacOSConfigurationProfileSubsetSelfServi
 	// Check if all values are default
 	allDefault := true
 	for key, value := range selfServiceBlock {
-		if !reflect.DeepEqual(value, defaults[key]) {
+		if defaultVal, ok := defaults[key]; ok && !reflect.DeepEqual(value, defaultVal) {
 			allDefault = false
 			break
 		}
@@ -314,13 +302,6 @@ func setSelfService(selfService jamfpro.MacOSConfigurationProfileSubsetSelfServi
 	if allDefault {
 		log.Println("All self service values are default, skipping state")
 		return nil, nil
-	}
-
-	// Remove default values
-	for key, value := range selfServiceBlock {
-		if reflect.DeepEqual(value, defaults[key]) {
-			delete(selfServiceBlock, key)
-		}
 	}
 
 	log.Println("Initializing self service in state")


### PR DESCRIPTION
Refined logic for updating macos plist resources. the new logic obtains the jamfpro generated post request payloadUUID at root and within the payload recursively. it then injects the jamf pro generated values into the update request.

