### PR TITLE
Prevent unnecessary escaping of double quotes

### DIFF
--- a/internal/resources/common/configurationprofiles/plist/shared.go
+++ b/internal/resources/common/configurationprofiles/plist/shared.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"log"
 	"sort"
+	"strings"
 
 	"howett.net/plist"
 )
@@ -33,6 +34,9 @@ func EncodePlist(cleanedData map[string]interface{}) (string, error) {
 	}
 
 	encodedString := buffer.String()
+
+	// Post-process to remove unnecessary escaped characters while keeping essential ones
+	encodedString = strings.ReplaceAll(encodedString, "&#34;", "\"") // Fix double quotes
 
 	return encodedString, nil
 }


### PR DESCRIPTION
Added a post-processing step to replace escaped double quotes (`&#34;`) with standard quotes (`"`) that is added by `plist.NewEncoder`. This is causing the payloads like TCC to be improperly escaped when uploaded to Jamf. 

Previously: 
```
							<key>CodeRequirement</key>
							<string>identifier &#34;com.example.service&#34; and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = ABCDEFG</string>
```

Now:
```
							<key>CodeRequirement</key>
							<string>identifier "com.example.service" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = ABCDEFG </string>
```
