### PR TITLE
feat: added plist validation for PayloadName and PayloadDescription

### DIFF
--- a/internal/resources/common/configurationprofiles/plist/validate.go
+++ b/internal/resources/common/configurationprofiles/plist/validate.go
@@ -1,5 +1,4 @@
 // common/configurationprofiles/plist/validate.go
-// Description: This file contains the Configuration Profile validation functions.
 package plist
 
 import (

--- a/internal/resources/common/configurationprofiles/plist/validate.go
+++ b/internal/resources/common/configurationprofiles/plist/validate.go
@@ -27,7 +27,7 @@ func ValidatePayloadFields(profile *ConfigurationProfile) []error {
 			if strings.Contains(tag, "required") {
 				value := val.Field(i).Interface()
 				if value == "" {
-					errs = append(errs, fmt.Errorf(fmt.Sprintf("plist key '%s' is required", field.Name)))
+					errs = append(errs, fmt.Errorf("plist key '%s' is required", field.Name))
 				}
 			}
 			// Additional validation rules can be added here

--- a/internal/resources/macosconfigurationprofilesplist/data_validator.go
+++ b/internal/resources/macosconfigurationprofilesplist/data_validator.go
@@ -25,7 +25,15 @@ func mainCustomDiffFunc(ctx context.Context, diff *schema.ResourceDiff, i interf
 			return err
 		}
 
-		if err := validateMacOSConfigurationProfileLevel(ctx, diff, i); err != nil {
+		if err := validatePlistPayloadScope(ctx, diff, i); err != nil {
+			return err
+		}
+
+		if err := validatePlistPayloadName(ctx, diff, i); err != nil {
+			return err
+		}
+
+		if err := validatePlistPayloadDescription(ctx, diff, i); err != nil {
 			return err
 		}
 	}
@@ -94,8 +102,8 @@ func validateDistributionMethod(_ context.Context, diff *schema.ResourceDiff, _ 
 	return nil
 }
 
-// validateMacOSConfigurationProfileLevel validates that the 'PayloadScope' key in the payload matches the 'level' attribute.
-func validateMacOSConfigurationProfileLevel(_ context.Context, diff *schema.ResourceDiff, _ interface{}) error {
+// validatePlistPayloadScope validates that the 'PayloadScope' key in the payload matches the 'level' attribute in the HCL.
+func validatePlistPayloadScope(_ context.Context, diff *schema.ResourceDiff, _ interface{}) error {
 	resourceName := diff.Get("name").(string)
 	level := diff.Get("level").(string)
 	payloads := diff.Get("payloads").(string)
@@ -111,7 +119,55 @@ func validateMacOSConfigurationProfileLevel(_ context.Context, diff *schema.Reso
 	}
 
 	if payloadScope != level {
-		return fmt.Errorf("in 'jamfpro_macos_configuration_profile.%s': hcl 'level' attribute (%s) does not match the 'PayloadScope' in the root dict of the plist (%s); the values must be identical", resourceName, level, payloadScope)
+		return fmt.Errorf("in 'jamfpro_macos_configuration_profile.%s': the hcl 'level' attribute (%s) does not match the 'PayloadScope' in the root dict of the plist (%s); the values must be identical", resourceName, level, payloadScope)
+	}
+
+	return nil
+}
+
+// validatePlistPayloadName validates that the root PayloadDisplayName in the plist matches the name field in HCL.
+func validatePlistPayloadName(_ context.Context, diff *schema.ResourceDiff, _ interface{}) error {
+	resourceName := diff.Get("name").(string)
+	payload := diff.Get("payloads").(string)
+
+	profile, err := plist.UnmarshalPayload(payload)
+	if err != nil {
+		return fmt.Errorf("in 'jamfpro_macos_configuration_profile_plist.%s': error unmarshalling payload: %v", resourceName, err)
+	}
+
+	if profile.PayloadDisplayName != resourceName {
+		return fmt.Errorf("in 'jamfpro_macos_configuration_profile_plist.%s': the plist root PayloadDisplayName field is ('%s') which does not match the HCL 'name' attribute ('%s'); the values must be identical",
+			resourceName,
+			profile.PayloadDisplayName,
+			resourceName)
+	}
+
+	return nil
+}
+
+// validatePlistPayloadDescription performs the payload description validation that validates the root
+// PayloadDescription matches resource description in the HCL
+func validatePlistPayloadDescription(_ context.Context, diff *schema.ResourceDiff, _ interface{}) error {
+	resourceName := diff.Get("name").(string)
+	resourceDesc := diff.Get("description").(string)
+	payload := diff.Get("payloads").(string)
+
+	// Only proceed if we have payload validation enabled
+	if !diff.Get("payload_validate").(bool) {
+		return nil
+	}
+
+	profile, err := plist.UnmarshalPayload(payload)
+	if err != nil {
+		return fmt.Errorf("in 'jamfpro_macos_configuration_profile_plist.%s': error unmarshalling payload: %v", resourceName, err)
+	}
+
+	// Compare PayloadDescription with resource description
+	if profile.PayloadDescription != resourceDesc {
+		return fmt.Errorf("in 'jamfpro_macos_configuration_profile_plist.%s': the plist root PayloadDescription field is ('%s') which does not match the HCL 'description' attribute ('%s'); the values must be identical",
+			resourceName,
+			profile.PayloadDescription,
+			resourceDesc)
 	}
 
 	return nil

--- a/internal/resources/macosconfigurationprofilesplist/payload_diff_suppress.go
+++ b/internal/resources/macosconfigurationprofilesplist/payload_diff_suppress.go
@@ -38,7 +38,7 @@ func DiffSuppressPayloads(k, old, new string, d *schema.ResourceData) bool {
 // and normalizes the base64 content, XML tags, empty strings, and HTML entities.
 func processPayload(payload string, source string) (string, error) {
 	fmt.Printf("Processing %s: %s", source, payload)
-	fieldsToRemove := []string{"PayloadUUID", "PayloadIdentifier", "PayloadOrganization", "PayloadDisplayName"}
+	fieldsToRemove := []string{"PayloadUUID", "PayloadIdentifier", "PayloadOrganization"}
 	processedPayload, err := plist.ProcessConfigurationProfileForDiffSuppression(payload, fieldsToRemove)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Since jamf pro post processes any uploaded plist config profile for fields `PayloadDisplayName` & `PayloadDescription` with the config profile resource fields `name` and `description` respectively, it's therefore deterministic. Unlike uuid and other fields that are randomised.

therefore this validation ensures that what's set with what the jamf pro server expects. 