### PR TITLE
fix: package uploads no longer timeout, metadata and upload are separate operations now.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ toolchain go1.23.3
 
 // Deploymenttheory
 require (
-	github.com/deploymenttheory/go-api-http-client v0.4.1-0.20250313162137-7021984674b1
+	github.com/deploymenttheory/go-api-http-client v0.4.1
 	github.com/deploymenttheory/go-api-http-client-integrations v0.0.13
 	github.com/deploymenttheory/go-api-sdk-jamfpro v1.25.3-0.20250313162544-857bac593837
 )

--- a/go.mod
+++ b/go.mod
@@ -8,9 +8,9 @@ toolchain go1.23.3
 
 // Deploymenttheory
 require (
-	github.com/deploymenttheory/go-api-http-client v0.4.0
+	github.com/deploymenttheory/go-api-http-client v0.4.1-0.20250313162137-7021984674b1
 	github.com/deploymenttheory/go-api-http-client-integrations v0.0.13
-	github.com/deploymenttheory/go-api-sdk-jamfpro v1.25.2
+	github.com/deploymenttheory/go-api-sdk-jamfpro v1.25.3-0.20250313162544-857bac593837
 )
 
 // Other

--- a/go.sum
+++ b/go.sum
@@ -76,12 +76,12 @@ github.com/cyphar/filepath-securejoin v0.2.5/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxG
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/deploymenttheory/go-api-http-client v0.4.0 h1:YSgt8Gx3LzmSh5Pjt7zJ6ilAuTCmsy9Wzo2V4NajXmw=
-github.com/deploymenttheory/go-api-http-client v0.4.0/go.mod h1:wJIFm4S1jj4io+G3E3pxyhmHQXXiZ5ft0xZxorsWOSo=
+github.com/deploymenttheory/go-api-http-client v0.4.1-0.20250313162137-7021984674b1 h1:2rEeA034vuT+QBxqfTfUh3kQmPwVZBhhEl5/uSdvpfI=
+github.com/deploymenttheory/go-api-http-client v0.4.1-0.20250313162137-7021984674b1/go.mod h1:wJIFm4S1jj4io+G3E3pxyhmHQXXiZ5ft0xZxorsWOSo=
 github.com/deploymenttheory/go-api-http-client-integrations v0.0.13 h1:zqGfWtdtRpYaCcsje2//Hpha1eSO0vblbSVvRr8ax7k=
 github.com/deploymenttheory/go-api-http-client-integrations v0.0.13/go.mod h1:m9XNzP2pNsw8eg+Bdqjrnmn/QK1vrGsDDboabc//IdQ=
-github.com/deploymenttheory/go-api-sdk-jamfpro v1.25.2 h1:WA2yifaAraWN5G9FxF7OMELmsNB0daoIWi/zvIXleAY=
-github.com/deploymenttheory/go-api-sdk-jamfpro v1.25.2/go.mod h1:bHeFOqgG1lsl5g8cAHljTzBnHzXWWtfgoNdTSpI20iE=
+github.com/deploymenttheory/go-api-sdk-jamfpro v1.25.3-0.20250313162544-857bac593837 h1:hm2WIqqiDH4UxIIqKhwueZ0skHofnJbh6iCRSlDAkjI=
+github.com/deploymenttheory/go-api-sdk-jamfpro v1.25.3-0.20250313162544-857bac593837/go.mod h1:RN6gmaKUV2fvBoYl3zcRABubjRrcoMyDHBYS0rVzRF4=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=

--- a/go.sum
+++ b/go.sum
@@ -76,8 +76,8 @@ github.com/cyphar/filepath-securejoin v0.2.5/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxG
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/deploymenttheory/go-api-http-client v0.4.1-0.20250313162137-7021984674b1 h1:2rEeA034vuT+QBxqfTfUh3kQmPwVZBhhEl5/uSdvpfI=
-github.com/deploymenttheory/go-api-http-client v0.4.1-0.20250313162137-7021984674b1/go.mod h1:wJIFm4S1jj4io+G3E3pxyhmHQXXiZ5ft0xZxorsWOSo=
+github.com/deploymenttheory/go-api-http-client v0.4.1 h1:NPvlOs2XT/QbF3r1LbKq7Wgzab6dt517hiysihRVjK0=
+github.com/deploymenttheory/go-api-http-client v0.4.1/go.mod h1:wJIFm4S1jj4io+G3E3pxyhmHQXXiZ5ft0xZxorsWOSo=
 github.com/deploymenttheory/go-api-http-client-integrations v0.0.13 h1:zqGfWtdtRpYaCcsje2//Hpha1eSO0vblbSVvRr8ax7k=
 github.com/deploymenttheory/go-api-http-client-integrations v0.0.13/go.mod h1:m9XNzP2pNsw8eg+Bdqjrnmn/QK1vrGsDDboabc//IdQ=
 github.com/deploymenttheory/go-api-sdk-jamfpro v1.25.3-0.20250313162544-857bac593837 h1:hm2WIqqiDH4UxIIqKhwueZ0skHofnJbh6iCRSlDAkjI=

--- a/internal/resources/packages/crud.go
+++ b/internal/resources/packages/crud.go
@@ -59,6 +59,11 @@ func create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.
 		return nil
 	})
 
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("failed to make the metadata, exiting: %v", err))
+
+	}
+
 	// Package - Timeout temporarily hard coded
 	err = retry.RetryContext(ctx, 60*time.Minute, func() *retry.RetryError {
 		_, err = client.UploadPackage(packageID, []string{localFilePath})

--- a/internal/resources/packages/crud.go
+++ b/internal/resources/packages/crud.go
@@ -85,7 +85,7 @@ func create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.
 
 	if err != nil {
 
-		// Cleanup the metadata so the next run doesn't hit an error trying to remake you
+		// Cleans up the metadata so the next run doesn't hit an error trying to remake it, duplicate names are not allowed
 		cleanupErr := client.DeletePackageByID(packageID)
 
 		if cleanupErr != nil {

--- a/internal/resources/packages/crud.go
+++ b/internal/resources/packages/crud.go
@@ -44,9 +44,6 @@ func create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.
 		return diag.FromErr(fmt.Errorf("failed to calculate SHA3-512: %v", err))
 	}
 
-	client.HTTP.ModifyHttpTimeout(PackagesHttpTimeout)
-	defer client.HTTP.ResetTimeout()
-
 	// Meta
 	err = retry.RetryContext(ctx, d.Timeout(schema.TimeoutCreate), func() *retry.RetryError {
 		creationResponse, err := client.CreatePackage(*resource)
@@ -63,6 +60,9 @@ func create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.
 		return diag.FromErr(fmt.Errorf("failed to make the metadata, exiting: %v", err))
 
 	}
+
+	client.HTTP.ModifyHttpTimeout(PackagesHttpTimeout)
+	defer client.HTTP.ResetTimeout()
 
 	// Package - Timeout temporarily hard coded
 	err = retry.RetryContext(ctx, 60*time.Minute, func() *retry.RetryError {


### PR DESCRIPTION
Mainly moving to latest SDK and HTTP client versions which fix the bug, please see those releases for detail.

Also changed the metadata/upload flow to be two separate retry operations with individual timeouts.