### PR TITLE
fix: for '&' handling within plists for macos and mobile devices

### DIFF
--- a/internal/resources/common/configurationprofiles/plist/diff_suppression.go
+++ b/internal/resources/common/configurationprofiles/plist/diff_suppression.go
@@ -211,31 +211,11 @@ func normalizeEmptyStrings(data interface{}) interface{} {
 	}
 }
 
-// unescapeHTMLEntities applies html.UnescapeString recursively
-// jamfpro configuration profiles contain html entities that need
-// to be unescaped for comparison
-//
-//	func unescapeHTMLEntities(data interface{}) interface{} {
-//		switch v := data.(type) {
-//		case string:
-//			return html.UnescapeString(v)
-//		case map[string]interface{}:
-//			for key, value := range v {
-//				v[key] = unescapeHTMLEntities(value)
-//			}
-//		case []interface{}:
-//			for i, item := range v {
-//				v[i] = unescapeHTMLEntities(item)
-//			}
-//		}
-//		return data
-//	}
-//
-// unescapeHTMLEntities applies html.UnescapeString recursively,
-// but avoids double-unescaping or unescaping intentionally escaped XML entities.
 // safeHTMLEntity is a regex to detect a single-level valid entity like &lt;, &amp;, etc.
 var safeHTMLEntity = regexp.MustCompile(`&[a-zA-Z]+;`)
 
+// normalizeHTMLEntitiesForDiff applies html.UnescapeString recursively,
+// but avoids double-unescaping or unescaping intentionally escaped XML entities.
 func normalizeHTMLEntitiesForDiff(data interface{}) interface{} {
 	switch v := data.(type) {
 	case string:

--- a/internal/resources/common/configurationprofiles/plist/shared_test.go
+++ b/internal/resources/common/configurationprofiles/plist/shared_test.go
@@ -58,26 +58,14 @@ func TestSortPlistKeys(t *testing.T) {
 			name: "Dictionary with array of dictionaries",
 			input: map[string]interface{}{
 				"array": []interface{}{
-					map[string]interface{}{
-						"b": 2,
-						"a": 1,
-					},
-					map[string]interface{}{
-						"d": 4,
-						"c": 3,
-					},
+					map[string]interface{}{"b": 2, "a": 1},
+					map[string]interface{}{"d": 4, "c": 3},
 				},
 			},
 			want: map[string]interface{}{
 				"array": []interface{}{
-					map[string]interface{}{
-						"a": 1,
-						"b": 2,
-					},
-					map[string]interface{}{
-						"c": 3,
-						"d": 4,
-					},
+					map[string]interface{}{"a": 1, "b": 2},
+					map[string]interface{}{"c": 3, "d": 4},
 				},
 			},
 		},
@@ -110,70 +98,18 @@ func TestSortPlistKeys(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := SortPlistKeys(tt.input)
+			assert.Equal(t, tt.want, got, "unexpected sorted output")
 
-			// Deep equality check
-			assert.Equal(t, tt.want, got)
-
-			// Helper function to get sorted keys from a map
-			getKeys := func(m map[string]interface{}) []string {
-				keys := make([]string, 0, len(m))
-				for k := range m {
-					keys = append(keys, k)
-				}
-				sort.Strings(keys)
-				return keys
-			}
-
-			// Helper function to verify if keys are in order
-			areKeysSorted := func(m map[string]interface{}) bool {
-				keys := make([]string, 0, len(m))
-				for k := range m {
-					keys = append(keys, k)
-				}
-				return sort.SliceIsSorted(keys, func(i, j int) bool {
-					return keys[i] < keys[j]
-				})
-			}
-
-			// Verify all nested structures recursively
-			var verifyNestedStructure func(v interface{}) bool
-			verifyNestedStructure = func(v interface{}) bool {
-				switch x := v.(type) {
-				case map[string]interface{}:
-					if !areKeysSorted(x) {
-						return false
-					}
-					for _, val := range x {
-						if !verifyNestedStructure(val) {
-							return false
-						}
-					}
-				case []interface{}:
-					for _, item := range x {
-						if m, ok := item.(map[string]interface{}); ok {
-							if !verifyNestedStructure(m) {
-								return false
-							}
-						}
-					}
-				}
-				return true
-			}
-
-			// Verify the entire structure
-			if !verifyNestedStructure(got) {
-				t.Error("structure contains unsorted keys")
-			}
-
-			// Additional specific checks for particular test cases
+			// Extra check only for array-of-maps case
 			if tt.name == "Dictionary with array of dictionaries" {
 				if arr, ok := got["array"].([]interface{}); ok {
-					for _, item := range arr {
-						if dict, ok := item.(map[string]interface{}); ok {
-							keys := getKeys(dict)
-							assert.True(t, sort.SliceIsSorted(keys, func(i, j int) bool {
-								return keys[i] < keys[j]
-							}), "dictionary in array should have sorted keys")
+					for i, item := range arr {
+						if m, ok := item.(map[string]interface{}); ok {
+							keys := make([]string, 0, len(m))
+							for k := range m {
+								keys = append(keys, k)
+							}
+							assert.True(t, sort.StringsAreSorted(keys), "map at array[%d] keys not sorted", i)
 						}
 					}
 				}

--- a/internal/resources/common/configurationprofiles/plist/uuid_handling.go
+++ b/internal/resources/common/configurationprofiles/plist/uuid_handling.go
@@ -2,8 +2,12 @@ package plist
 
 import "fmt"
 
-// extractUUIDs recursively extracts config profile UUIDs from a plist structure
-// and stores them in a map by PayloadDisplayName.
+// ExtractUUIDs recursively traverses a plist structure represented as nested maps and slices,
+// extracting all occurrences of `PayloadUUID` and associating them with their respective
+// `PayloadDisplayName`. It stores these key-value pairs in the provided `uuidMap`.
+// If a `PayloadDisplayName` is absent at the root level, it uses the special key "root".
+// This function is typically used to map existing UUIDs from a configuration profile
+// retrieved from Jamf Pro.
 func ExtractUUIDs(data interface{}, uuidMap map[string]string) {
 	switch v := data.(type) {
 	case map[string]interface{}:
@@ -28,8 +32,12 @@ func ExtractUUIDs(data interface{}, uuidMap map[string]string) {
 	}
 }
 
-// updateUUIDs recursively updates config profile UUIDs in a
-// plist structure
+// UpdateUUIDs recursively traverses a plist structure represented as nested maps and slices,
+// updating the values of `PayloadUUID` and `PayloadIdentifier` fields using the UUIDs
+// provided in `uuidMap`. It matches UUIDs based on `PayloadDisplayName`. If a `PayloadDisplayName`
+// is absent at the root level, it uses the special key "root" from the map.
+// This function ensures that configuration profile UUIDs remain consistent with Jamf Pro
+// expectations during Terraform update operations.
 func UpdateUUIDs(data interface{}, uuidMap map[string]string) {
 	switch v := data.(type) {
 	case map[string]interface{}:
@@ -57,6 +65,12 @@ func UpdateUUIDs(data interface{}, uuidMap map[string]string) {
 	}
 }
 
+// ValidatePayloadUUIDsMatch recursively compares UUID-related fields (`PayloadUUID` and
+// `PayloadIdentifier`) between two plist structures (`existingPlist` and `newPlist`) to
+// confirm they match exactly. It accumulates any differences found into the provided
+// `mismatches` slice, describing the exact path and mismatched values.
+// This validation step ensures Terraform updates maintain consistency with Jamf Pro’s
+// UUID requirements and detects unintended modifications.
 func ValidatePayloadUUIDsMatch(existingPlist, newPlist interface{}, path string, mismatches *[]string) {
 	existingMap, existingOk := existingPlist.(map[string]interface{})
 	newMap, newOk := newPlist.(map[string]interface{})

--- a/internal/resources/common/configurationprofiles/plist/uuid_handling.go
+++ b/internal/resources/common/configurationprofiles/plist/uuid_handling.go
@@ -1,5 +1,7 @@
 package plist
 
+import "fmt"
+
 // extractUUIDs recursively extracts config profile UUIDs from a plist structure
 // and stores them in a map by PayloadDisplayName.
 func ExtractUUIDs(data interface{}, uuidMap map[string]string) {
@@ -51,6 +53,46 @@ func UpdateUUIDs(data interface{}, uuidMap map[string]string) {
 	case []interface{}:
 		for _, item := range v {
 			UpdateUUIDs(item, uuidMap)
+		}
+	}
+}
+
+func ValidatePayloadUUIDsMatch(existingPlist, newPlist interface{}, path string, mismatches *[]string) {
+	existingMap, existingOk := existingPlist.(map[string]interface{})
+	newMap, newOk := newPlist.(map[string]interface{})
+
+	if existingOk && newOk {
+		for key, existingValue := range existingMap {
+			newValue, exists := newMap[key]
+
+			// Build the full path for clear logging
+			currentPath := path + "/" + key
+
+			if !exists {
+				continue // Ignore keys that don't exist in the new payload
+			}
+
+			switch key {
+			case "PayloadUUID", "PayloadIdentifier":
+				existingUUID, existingIsString := existingValue.(string)
+				newUUID, newIsString := newValue.(string)
+
+				if existingIsString && newIsString && existingUUID != newUUID {
+					*mismatches = append(*mismatches, fmt.Sprintf("%s (Jamf Pro: %s, Request: %s)", currentPath, existingUUID, newUUID))
+				}
+			default:
+				ValidatePayloadUUIDsMatch(existingValue, newValue, currentPath, mismatches)
+			}
+		}
+	} else if existingSlice, ok := existingPlist.([]interface{}); ok {
+		if newSlice, newOk := newPlist.([]interface{}); newOk {
+			minLen := len(existingSlice)
+			if len(newSlice) < minLen {
+				minLen = len(newSlice)
+			}
+			for i := 0; i < minLen; i++ {
+				ValidatePayloadUUIDsMatch(existingSlice[i], newSlice[i], fmt.Sprintf("%s[%d]", path, i), mismatches)
+			}
 		}
 	}
 }

--- a/internal/resources/macosconfigurationprofilesplist/constructor.go
+++ b/internal/resources/macosconfigurationprofilesplist/constructor.go
@@ -76,7 +76,7 @@ func constructJamfProMacOSConfigurationProfilePlist(d *schema.ResourceData, mode
 		resource.SelfService = constructMacOSConfigurationProfileSubsetSelfService(selfServiceData)
 	}
 
-	// Add debug to see existing profile
+	// if update get the existing config profile from jamf
 	if mode == "update" {
 		client := meta.(*jamfpro.Client)
 		resourceID := d.Id()
@@ -85,11 +85,6 @@ func constructJamfProMacOSConfigurationProfilePlist(d *schema.ResourceData, mode
 		if err != nil {
 			return nil, fmt.Errorf("failed to get existing configuration profile by ID for update operation: %v", err)
 		}
-
-		// Debug: Print the stored payload from Jamf Pro
-		fmt.Println("====== JAMF PRO STORED PAYLOAD ======")
-		fmt.Println(existingProfile.General.Payloads)
-		fmt.Println("=====================================")
 	}
 
 	if mode != "update" {
@@ -140,11 +135,6 @@ func constructJamfProMacOSConfigurationProfilePlist(d *schema.ResourceData, mode
 
 		// Since we're sending Plist formatted as xml (payload) inside XML (request), we need to HTML-escape for plist within xml once.
 		resource.General.Payloads = html.EscapeString(buf.String())
-
-		// 🔍 Debug: Print the final plist payload for inspection
-		fmt.Println("====== Final Payload Plist (after UUID injection) ======")
-		fmt.Println(resource.General.Payloads)
-		fmt.Println("========================================================")
 	}
 
 	resourceXML, err := xml.MarshalIndent(resource, "", "  ")

--- a/internal/resources/macosconfigurationprofilesplist/constructor.go
+++ b/internal/resources/macosconfigurationprofilesplist/constructor.go
@@ -69,7 +69,7 @@ func constructJamfProMacOSConfigurationProfilePlist(d *schema.ResourceData, mode
 			Level:              d.Get("level").(string),
 			UUID:               d.Get("uuid").(string),
 			RedeployOnUpdate:   d.Get("redeploy_on_update").(string),
-			Payloads:           html.EscapeString(d.Get("payloads").(string)),
+			Payloads:           d.Get("payloads").(string),
 		},
 	}
 
@@ -96,7 +96,9 @@ func constructJamfProMacOSConfigurationProfilePlist(d *schema.ResourceData, mode
 			return nil, fmt.Errorf("failed to decode existing plist: %v", err)
 		}
 
-		// Decode new payload from Terraform
+		// Decode new payload from Terraform state
+		// require html.UnescapeString because the payload XML stored in Terraform state has been HTML-escaped
+		// (e.g., &lt;, &gt;, &amp;) to safely store XML as a string within JSON-based Terraform state.
 		newPayload := html.UnescapeString(resource.General.Payloads)
 		if err := plist.NewDecoder(strings.NewReader(newPayload)).Decode(&newPlist); err != nil {
 			return nil, fmt.Errorf("failed to decode new plist: %v", err)

--- a/internal/resources/macosconfigurationprofilesplist/constructor.go
+++ b/internal/resources/macosconfigurationprofilesplist/constructor.go
@@ -42,6 +42,11 @@ import (
 // Returns:
 // - Constructed ResourceMacOSConfigurationProfile
 // - Error if construction or API calls fail
+//
+// Jamf Pro modifies the top-level PayloadUUID and PayloadIdentifier upon profile creation.
+// Nested payload identifiers and UUIDs remain unchanged from the original request.
+// Therefore, when performing profile updates, only top-level PayloadUUID and PayloadIdentifier
+// need to be synced from Jamf Pro's existing profile state.
 func constructJamfProMacOSConfigurationProfilePlist(d *schema.ResourceData, mode string, meta interface{}) (*jamfpro.ResourceMacOSConfigurationProfile, error) {
 	var existingProfile *jamfpro.ResourceMacOSConfigurationProfile
 
@@ -81,31 +86,52 @@ func constructJamfProMacOSConfigurationProfilePlist(d *schema.ResourceData, mode
 		resource.SelfService = constructMacOSConfigurationProfileSubsetSelfService(selfServiceData)
 	}
 
-	// Handle UUID injection for update operations
 	if mode == "update" && existingProfile != nil {
-		uuidMap := make(map[string]string)
 		var existingPlist map[string]interface{}
-		existingPayload := html.UnescapeString(existingProfile.General.Payloads)
+		var newPlist map[string]interface{}
+
+		// Decode existing payload from Jamf Pro
+		existingPayload := existingProfile.General.Payloads
 		if err := plist.NewDecoder(strings.NewReader(existingPayload)).Decode(&existingPlist); err != nil {
 			return nil, fmt.Errorf("failed to decode existing plist: %v", err)
 		}
 
-		helpers.ExtractUUIDs(existingPlist, uuidMap)
-
-		var newPlist map[string]interface{}
+		// Decode new payload from Terraform
 		newPayload := html.UnescapeString(resource.General.Payloads)
 		if err := plist.NewDecoder(strings.NewReader(newPayload)).Decode(&newPlist); err != nil {
 			return nil, fmt.Errorf("failed to decode new plist: %v", err)
 		}
 
+		// Insight:
+		// Jamf Pro modifies only the top-level PayloadUUID and PayloadIdentifier upon profile creation.
+		// All nested payload UUIDs/identifiers remain unchanged.
+		// So we must copy Jamf Pro's top-level identifiers into the newPlist before validation.
+
+		// Copy top-level PayloadUUID and PayloadIdentifier from existing (Jamf Pro) to new (Terraform)
+		newPlist["PayloadUUID"] = existingPlist["PayloadUUID"]
+		newPlist["PayloadIdentifier"] = existingPlist["PayloadIdentifier"]
+
+		// Ensure nested UUIDs are also matched properly
+		uuidMap := make(map[string]string)
+		helpers.ExtractUUIDs(existingPlist, uuidMap)
 		helpers.UpdateUUIDs(newPlist, uuidMap)
 
+		// Validate the PayloadUUIDs match exactly now
+		var mismatches []string
+		helpers.ValidatePayloadUUIDsMatch(existingPlist, newPlist, "Payload", &mismatches)
+
+		if len(mismatches) > 0 {
+			return nil, fmt.Errorf("configuration profile UUID mismatch found:\n%s", strings.Join(mismatches, "\n"))
+		}
+
+		// Encode the correctly updated plist
 		var buf bytes.Buffer
 		encoder := plist.NewEncoder(&buf)
 		encoder.Indent("    ")
 		if err := encoder.Encode(newPlist); err != nil {
 			return nil, fmt.Errorf("failed to encode updated plist: %v", err)
 		}
+
 		resource.General.Payloads = buf.String()
 	}
 

--- a/internal/resources/macosconfigurationprofilesplist/constructor.go
+++ b/internal/resources/macosconfigurationprofilesplist/constructor.go
@@ -50,16 +50,6 @@ import (
 func constructJamfProMacOSConfigurationProfilePlist(d *schema.ResourceData, mode string, meta interface{}) (*jamfpro.ResourceMacOSConfigurationProfile, error) {
 	var existingProfile *jamfpro.ResourceMacOSConfigurationProfile
 
-	if mode == "update" {
-		client := meta.(*jamfpro.Client)
-		resourceID := d.Id()
-		var err error
-		existingProfile, err = client.GetMacOSConfigurationProfileByID(resourceID)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get existing profile: %v", err)
-		}
-	}
-
 	resource := &jamfpro.ResourceMacOSConfigurationProfile{
 		General: jamfpro.MacOSConfigurationProfileSubsetGeneral{
 			Name:               d.Get("name").(string),
@@ -85,6 +75,16 @@ func constructJamfProMacOSConfigurationProfilePlist(d *schema.ResourceData, mode
 	if v, ok := d.GetOk("self_service"); ok {
 		selfServiceData := v.([]interface{})[0].(map[string]interface{})
 		resource.SelfService = constructMacOSConfigurationProfileSubsetSelfService(selfServiceData)
+	}
+
+	if mode == "update" {
+		client := meta.(*jamfpro.Client)
+		resourceID := d.Id()
+		var err error
+		existingProfile, err = client.GetMacOSConfigurationProfileByID(resourceID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get existing configuration profile by ID for update operation: %v", err)
+		}
 	}
 
 	if mode == "update" && existingProfile != nil {

--- a/internal/resources/macosconfigurationprofilesplist/constructor.go
+++ b/internal/resources/macosconfigurationprofilesplist/constructor.go
@@ -77,8 +77,14 @@ func constructJamfProMacOSConfigurationProfilePlist(d *schema.ResourceData, mode
 		resource.SelfService = constructMacOSConfigurationProfileSubsetSelfService(selfServiceData)
 	}
 
-	// if update get the existing config profile from jamf
-	if mode == "update" {
+	if mode != "update" {
+
+		resource.General.Payloads = html.EscapeString(d.Get("payloads").(string))
+
+	} else if mode == "update" {
+		var existingPlist map[string]interface{}
+		var newPlist map[string]interface{}
+
 		client := meta.(*jamfpro.Client)
 		resourceID := d.Id()
 		var err error
@@ -86,15 +92,6 @@ func constructJamfProMacOSConfigurationProfilePlist(d *schema.ResourceData, mode
 		if err != nil {
 			return nil, fmt.Errorf("failed to get existing configuration profile by ID for update operation: %v", err)
 		}
-	}
-
-	if mode != "update" {
-
-		resource.General.Payloads = html.EscapeString(d.Get("payloads").(string))
-
-	} else if mode == "update" && existingProfile != nil {
-		var existingPlist map[string]interface{}
-		var newPlist map[string]interface{}
 
 		// Decode existing payload from Jamf Pro which has the jamf pro post processed uuid's etc
 		existingPayload := existingProfile.General.Payloads

--- a/internal/resources/macosconfigurationprofilesplist/data_validator.go
+++ b/internal/resources/macosconfigurationprofilesplist/data_validator.go
@@ -4,7 +4,6 @@ package macosconfigurationprofilesplist
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/deploymenttheory/terraform-provider-jamfpro/internal/resources/common/configurationprofiles/datavalidators"
 	"github.com/deploymenttheory/terraform-provider-jamfpro/internal/resources/common/configurationprofiles/plist"
@@ -30,9 +29,6 @@ func mainCustomDiffFunc(ctx context.Context, diff *schema.ResourceDiff, i interf
 			return err
 		}
 
-		if err := validateXMLescapedcharacters(ctx, diff, i); err != nil {
-			return err
-		}
 	}
 
 	if err := validateSelfServiceCategories(ctx, diff, i); err != nil {
@@ -117,18 +113,6 @@ func validatePlistPayloadScope(_ context.Context, diff *schema.ResourceDiff, _ i
 
 	if payloadScope != level {
 		return fmt.Errorf("in 'jamfpro_macos_configuration_profile.%s': the hcl 'level' attribute (%s) does not match the 'PayloadScope' in the root dict of the plist (%s); the values must be identical", resourceName, level, payloadScope)
-	}
-
-	return nil
-}
-
-// validateXMLescapedcharacters scans for common incorrectly escaped sequences like %2f and returns a warning.
-func validateXMLescapedcharacters(_ context.Context, diff *schema.ResourceDiff, _ interface{}) error {
-	resourceName := diff.Get("name").(string)
-	payload := diff.Get("payloads").(string)
-
-	if strings.Contains(strings.ToLower(payload), "%2f") {
-		return fmt.Errorf("in 'jamfpro_macos_configuration_profile_plist.%s': payload contains '%%2f' which should be a forward slash '/'", resourceName)
 	}
 
 	return nil

--- a/internal/resources/macosconfigurationprofilesplist/data_validator.go
+++ b/internal/resources/macosconfigurationprofilesplist/data_validator.go
@@ -4,6 +4,7 @@ package macosconfigurationprofilesplist
 import (
 	"context"
 	"fmt"
+	"regexp"
 
 	"github.com/deploymenttheory/terraform-provider-jamfpro/internal/resources/common/configurationprofiles/datavalidators"
 	"github.com/deploymenttheory/terraform-provider-jamfpro/internal/resources/common/configurationprofiles/plist"
@@ -26,6 +27,10 @@ func mainCustomDiffFunc(ctx context.Context, diff *schema.ResourceDiff, i interf
 		}
 
 		if err := validatePlistPayloadScope(ctx, diff, i); err != nil {
+			return err
+		}
+
+		if err := validatePlistStructure(ctx, diff, i); err != nil {
 			return err
 		}
 	}
@@ -112,6 +117,25 @@ func validatePlistPayloadScope(_ context.Context, diff *schema.ResourceDiff, _ i
 
 	if payloadScope != level {
 		return fmt.Errorf("in 'jamfpro_macos_configuration_profile.%s': the hcl 'level' attribute (%s) does not match the 'PayloadScope' in the root dict of the plist (%s); the values must be identical", resourceName, level, payloadScope)
+	}
+
+	return nil
+}
+
+// validatePlistStructure checks for common structural malformations in the raw payload XML.
+func validatePlistStructure(_ context.Context, diff *schema.ResourceDiff, _ interface{}) error {
+	resourceName := diff.Get("name").(string)
+	payload := diff.Get("payloads").(string)
+
+	// Look for cases where <dict> appears before <plist>
+	plistTag := regexp.MustCompile(`(?i)<plist[^>]*>`)
+	dictTag := regexp.MustCompile(`(?i)<dict>`)
+
+	plistIndex := plistTag.FindStringIndex(payload)
+	dictIndex := dictTag.FindStringIndex(payload)
+
+	if dictIndex != nil && plistIndex != nil && dictIndex[0] < plistIndex[0] {
+		return fmt.Errorf("in 'jamfpro_macos_configuration_profile_plist.%s': malformed XML — <dict> appears before <plist>. The <plist> element must come first in the payload", resourceName)
 	}
 
 	return nil

--- a/internal/resources/mobiledeviceconfigurationprofilesplist/constructor.go
+++ b/internal/resources/mobiledeviceconfigurationprofilesplist/constructor.go
@@ -16,19 +16,39 @@ import (
 	"howett.net/plist"
 )
 
-// constructJamfProMobileDeviceConfigurationProfile constructs a ResourceMobileDeviceConfigurationProfile object from the provided schema data.
+// constructJamfProMobileDeviceConfigurationProfilePlist constructs a ResourceMobileDeviceConfigurationProfile object from schema data.
+// It supports two modes:
+//   - create: Builds profile from schema data only
+//   - update: Fetches existing profile from Jamf Pro, extracts PayloadUUID/PayloadIdentifier values from existing plist,
+//     injects them into the new plist to maintain UUID continuity
+//
+// The function:
+// 1. For update mode:
+//   - Retrieves existing profile from Jamf Pro API
+//   - Decodes existing plist to extract UUIDs
+//
+// 2. Constructs base profile from schema data (name, description, etc)
+// 3. Builds scope and self-service sections if configured
+// 4. For update mode:
+//   - Maps existing UUIDs by PayloadDisplayName
+//   - Updates PayloadUUID/PayloadIdentifier in new plist to match existing
+//   - Re-encodes updated plist
+//
+// Parameters:
+// - d: Schema ResourceData containing configuration
+// - mode: "create" or "update" to control UUID handling
+// - meta: Provider meta containing client for API calls
+//
+// Returns:
+// - Constructed ResourceMacOSConfigurationProfile
+// - Error if construction or API calls fail
+//
+// Jamf Pro modifies the top-level PayloadUUID and PayloadIdentifier upon profile creation.
+// Nested payload identifiers and UUIDs remain unchanged from the original request.
+// Therefore, when performing profile updates, only top-level PayloadUUID and PayloadIdentifier
+// need to be synced from Jamf Pro's existing profile state.
 func constructJamfProMobileDeviceConfigurationProfilePlist(d *schema.ResourceData, mode string, meta interface{}) (*jamfpro.ResourceMobileDeviceConfigurationProfile, error) {
 	var existingProfile *jamfpro.ResourceMobileDeviceConfigurationProfile
-
-	if mode == "update" {
-		client := meta.(*jamfpro.Client)
-		resourceID := d.Id()
-		var err error
-		existingProfile, err = client.GetMobileDeviceConfigurationProfileByID(resourceID)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get existing profile: %v", err)
-		}
-	}
 
 	resource := &jamfpro.ResourceMobileDeviceConfigurationProfile{
 		General: jamfpro.MobileDeviceConfigurationProfileSubsetGeneral{
@@ -38,8 +58,7 @@ func constructJamfProMobileDeviceConfigurationProfilePlist(d *schema.ResourceDat
 			UUID:             d.Get("uuid").(string),
 			DeploymentMethod: d.Get("deployment_method").(string),
 			RedeployOnUpdate: d.Get("redeploy_on_update").(string),
-			// Use html.EscapeString to escape the payloads content
-			Payloads: html.EscapeString(d.Get("payloads").(string)),
+			// We'll handle payloads att differently based on mode
 		},
 	}
 
@@ -52,30 +71,39 @@ func constructJamfProMobileDeviceConfigurationProfilePlist(d *schema.ResourceDat
 		resource.Scope = constructMobileDeviceConfigurationProfileSubsetScope(scopeData)
 	}
 
-	if mode == "update" && existingProfile != nil {
+	// if update get the existing config profile from jamf
+	if mode == "update" {
+		client := meta.(*jamfpro.Client)
+		resourceID := d.Id()
+		var err error
+		existingProfile, err = client.GetMobileDeviceConfigurationProfileByID(resourceID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get existing configuration profile by ID for update operation: %v", err)
+		}
+	}
 
-		log.Printf("[DEBUG] Configuration Profile update operation initiated.")
+	if mode != "update" {
 
+		resource.General.Payloads = html.EscapeString(d.Get("payloads").(string))
+
+	} else if mode == "update" && existingProfile != nil {
 		var existingPlist map[string]interface{}
 		var newPlist map[string]interface{}
 
-		// Decode existing payload from Jamf Pro
+		// Decode existing payload from Jamf Pro which has the jamf pro post processed uuid's etc
 		existingPayload := existingProfile.General.Payloads
 		if err := plist.NewDecoder(strings.NewReader(existingPayload)).Decode(&existingPlist); err != nil {
-			return nil, fmt.Errorf("failed to decode existing plist: %v", err)
+			return nil, fmt.Errorf("failed to decode existing plist payload stored in jamf pro for update operation: %v", err)
 		}
 
-		// Decode new payload from Terraform
-		newPayload := html.UnescapeString(resource.General.Payloads)
+		// Decode payloads field from Terraform state ready for injection
+		newPayload := d.Get("payloads").(string)
 		if err := plist.NewDecoder(strings.NewReader(newPayload)).Decode(&newPlist); err != nil {
-			return nil, fmt.Errorf("failed to decode new plist: %v", err)
+			return nil, fmt.Errorf("failed to decode new plist payload from terraform state for update operation: %v", err)
 		}
 
-		// Insight:
 		// Jamf Pro modifies only the top-level PayloadUUID and PayloadIdentifier upon profile creation.
 		// All nested payload UUIDs/identifiers remain unchanged.
-		// So we must copy Jamf Pro's top-level identifiers into the newPlist before validation.
-
 		// Copy top-level PayloadUUID and PayloadIdentifier from existing (Jamf Pro) to new (Terraform)
 		newPlist["PayloadUUID"] = existingPlist["PayloadUUID"]
 		newPlist["PayloadIdentifier"] = existingPlist["PayloadIdentifier"]
@@ -85,7 +113,6 @@ func constructJamfProMobileDeviceConfigurationProfilePlist(d *schema.ResourceDat
 		helpers.ExtractUUIDs(existingPlist, uuidMap, true)
 		helpers.UpdateUUIDs(newPlist, uuidMap, true)
 
-		// Validate the PayloadUUIDs match exactly now
 		var mismatches []string
 		helpers.ValidatePayloadUUIDsMatch(existingPlist, newPlist, "Payload", &mismatches)
 
@@ -93,23 +120,24 @@ func constructJamfProMobileDeviceConfigurationProfilePlist(d *schema.ResourceDat
 			return nil, fmt.Errorf("configuration profile UUID mismatch found:\n%s", strings.Join(mismatches, "\n"))
 		}
 
-		// Encode the correctly updated plist
+		// Encode the plist with injections
 		var buf bytes.Buffer
 		encoder := plist.NewEncoder(&buf)
 		encoder.Indent("    ")
 		if err := encoder.Encode(newPlist); err != nil {
-			return nil, fmt.Errorf("failed to encode updated plist: %v", err)
+			return nil, fmt.Errorf("failed to encode plist payload with injected PayloadUUID and PayloadIdentifier: %v", err)
 		}
 
+		// Since we're sending Plist formatted as xml (payload) inside XML (request), we need to HTML-escape for plist within xml once.
 		resource.General.Payloads = html.EscapeString(buf.String())
 	}
 
 	resourceXML, err := xml.MarshalIndent(resource, "", "  ")
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal Jamf Pro Mobile Device Configuration Profile '%s' to XML: %v", resource.General.Name, err)
+		return nil, fmt.Errorf("failed to marshal Jamf Pro macOS Configuration Profile '%s' to XML: %v", resource.General.Name, err)
 	}
 
-	log.Printf("[DEBUG] Constructed Jamf Pro Mobile Device Configuration Profile XML:\n%s\n", string(resourceXML))
+	log.Printf("[DEBUG] Constructed Jamf Pro macOS Configuration Profile XML:\n%s\n", string(resourceXML))
 
 	return resource, nil
 }

--- a/internal/resources/mobiledeviceconfigurationprofilesplist/constructor.go
+++ b/internal/resources/mobiledeviceconfigurationprofilesplist/constructor.go
@@ -82,8 +82,8 @@ func constructJamfProMobileDeviceConfigurationProfilePlist(d *schema.ResourceDat
 
 		// Ensure nested UUIDs are also matched properly
 		uuidMap := make(map[string]string)
-		helpers.ExtractUUIDs(existingPlist, uuidMap)
-		helpers.UpdateUUIDs(newPlist, uuidMap)
+		helpers.ExtractUUIDs(existingPlist, uuidMap, true)
+		helpers.UpdateUUIDs(newPlist, uuidMap, true)
 
 		// Validate the PayloadUUIDs match exactly now
 		var mismatches []string
@@ -101,7 +101,7 @@ func constructJamfProMobileDeviceConfigurationProfilePlist(d *schema.ResourceDat
 			return nil, fmt.Errorf("failed to encode updated plist: %v", err)
 		}
 
-		resource.General.Payloads = buf.String()
+		resource.General.Payloads = html.EscapeString(buf.String())
 	}
 
 	resourceXML, err := xml.MarshalIndent(resource, "", "  ")

--- a/internal/resources/mobiledeviceconfigurationprofilesplist/constructor.go
+++ b/internal/resources/mobiledeviceconfigurationprofilesplist/constructor.go
@@ -53,6 +53,9 @@ func constructJamfProMobileDeviceConfigurationProfilePlist(d *schema.ResourceDat
 	}
 
 	if mode == "update" && existingProfile != nil {
+
+		log.Printf("[DEBUG] Configuration Profile update operation initiated.")
+
 		var existingPlist map[string]interface{}
 		var newPlist map[string]interface{}
 


### PR DESCRIPTION
- refactored logic for escaping and unescaping characters for update workflows
- fixed unit test logic
- replace html string replacement with finer grained specific handling for xml / plist / jamf pro needs
- preserves existing desired handling for " characters