### PR TITLE
fix: updated advancedmobiledevicesearches/resource.go to support device group membership criteria

### DIFF
--- a/internal/resources/advancedmobiledevicesearches/resource.go
+++ b/internal/resources/advancedmobiledevicesearches/resource.go
@@ -70,7 +70,8 @@ func ResourceJamfProAdvancedMobileDeviceSearches() *schema.Resource {
 							Required: true,
 							ValidateFunc: validation.StringInSlice([]string{
 								"is", "is not", "like", "not like", "has", "does not have",
-								"greater than", "less than", "greater than or equal", "less than or equal", "matches regex", "does not match regex",
+								"greater than", "less than", "greater than or equal", "less than or equal", 
+								"matches regex", "does not match regex", "member of", "not member of"
 							}, false),
 							Description: "Type of search to perform",
 						},


### PR DESCRIPTION
# Pull Request Description

## Summary
Added "member of" & "not member of" to the search type validation for Advanced Mobile Device Searches. 

### Issue Reference
Fixes #[Issue Number]

### Motivation and Context
Unable to create aAdvanced Mobile Device Searches, where the criteria was built on group membership as the search type for "member of" & "not member of was missing from the search type validation and would receive the following error 

```
│ Error: expected criteria.0.search_type to be one of ["is" "is not" "like" "not like" "has" "does not have" "greater than" "less than" "greater than or equal" "less than or equal" "matches regex" "does not match regex"], got member of
```

Adding "member of" & "not member of" to the search type validation resolves the issue.

### Dependencies
None

## Type of Change
Please mark the relevant option with an `x`:
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update (Wiki/README/Code comments)
- [ ] ♻️ Refactor (code improvement without functional changes)
- [ ] 🎨 Style update (formatting, renaming)
- [ ] 🔧 Configuration change
- [ ] 📦 Dependency update

## Testing
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this code in the following browsers/environments: [list environments]

## Quality Checklist
- [x] I have reviewed my own code before requesting review
- [x] I have verified there are no other open Pull Requests for the same update/change
- [ ] All CI/CD pipelines pass without errors or warnings
- [x] My code follows the established style guidelines of this project
- [ ] My comments are used only when necessary, ideally where the codes purpose is not self explanatory (eg: necessary magic numbers)
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have made corresponding changes to the README and other relevant documentation
- [ ] My changes generate no new warnings

## Screenshots/Recordings (if appropriate)
[Add screenshots or recordings that demonstrate the changes]

## Additional Notes
[Add any additional information that might be helpful for reviewers]