### PR TITLE
fix: for plist data validator to support sets rather than lists

### DIFF
--- a/internal/resources/macosconfigurationprofilesplist/data_validator.go
+++ b/internal/resources/macosconfigurationprofilesplist/data_validator.go
@@ -156,8 +156,10 @@ func validateAllComputersScope(_ context.Context, diff *schema.ResourceDiff, _ i
 	if allComputers {
 		fieldsToCheck := []string{"computer_ids", "computer_group_ids"}
 		for _, field := range fieldsToCheck {
-			if value, exists := scope[field]; exists && len(value.([]interface{})) > 0 {
-				return fmt.Errorf("in 'jamfpro_macos_configuration_profile_plist.%s': when 'all_computers' scope is set to true, '%s' should not be set", resourceName, field)
+			if value, exists := scope[field]; exists {
+				if setVal, ok := value.(*schema.Set); ok && setVal.Len() > 0 {
+					return fmt.Errorf("in 'jamfpro_macos_configuration_profile_plist.%s': when 'all_computers' scope is set to true, '%s' should not be set", resourceName, field)
+				}
 			}
 		}
 	}
@@ -173,13 +175,15 @@ func validateAllUsersScope(_ context.Context, diff *schema.ResourceDiff, _ inter
 	}
 
 	scope := scopeRaw.([]interface{})[0].(map[string]interface{})
-	allComputers := scope["all_jss_users"].(bool)
+	allJssUsers := scope["all_jss_users"].(bool)
 
-	if allComputers {
+	if allJssUsers {
 		fieldsToCheck := []string{"jss_user_ids", "jss_user_group_ids", "building_ids", "department_ids"}
 		for _, field := range fieldsToCheck {
-			if value, exists := scope[field]; exists && len(value.([]interface{})) > 0 {
-				return fmt.Errorf("in 'jamfpro_macos_configuration_profile_plist.%s': when 'all_jss_users' scope is set to true, '%s' should not be set", resourceName, field)
+			if value, exists := scope[field]; exists {
+				if setVal, ok := value.(*schema.Set); ok && setVal.Len() > 0 {
+					return fmt.Errorf("in 'jamfpro_macos_configuration_profile_plist.%s': when 'all_jss_users' scope is set to true, '%s' should not be set", resourceName, field)
+				}
 			}
 		}
 	}

--- a/internal/resources/macosconfigurationprofilesplistgenerator/data_validator.go
+++ b/internal/resources/macosconfigurationprofilesplistgenerator/data_validator.go
@@ -157,8 +157,10 @@ func validateAllComputersScope(_ context.Context, diff *schema.ResourceDiff, _ i
 	if allComputers {
 		fieldsToCheck := []string{"computer_ids", "computer_group_ids"}
 		for _, field := range fieldsToCheck {
-			if value, exists := scope[field]; exists && len(value.([]interface{})) > 0 {
-				return fmt.Errorf("in 'jamfpro_macos_configuration_profile_plist.%s': when 'all_computers' scope is set to true, '%s' should not be set", resourceName, field)
+			if value, exists := scope[field]; exists {
+				if setVal, ok := value.(*schema.Set); ok && setVal.Len() > 0 {
+					return fmt.Errorf("in 'jamfpro_macos_configuration_profile_plist.%s': when 'all_computers' scope is set to true, '%s' should not be set", resourceName, field)
+				}
 			}
 		}
 	}
@@ -174,13 +176,15 @@ func validateAllUsersScope(_ context.Context, diff *schema.ResourceDiff, _ inter
 	}
 
 	scope := scopeRaw.([]interface{})[0].(map[string]interface{})
-	allComputers := scope["all_jss_users"].(bool)
+	allJssUsers := scope["all_jss_users"].(bool)
 
-	if allComputers {
+	if allJssUsers {
 		fieldsToCheck := []string{"jss_user_ids", "jss_user_group_ids", "building_ids", "department_ids"}
 		for _, field := range fieldsToCheck {
-			if value, exists := scope[field]; exists && len(value.([]interface{})) > 0 {
-				return fmt.Errorf("in 'jamfpro_macos_configuration_profile_plist.%s': when 'all_jss_users' scope is set to true, '%s' should not be set", resourceName, field)
+			if value, exists := scope[field]; exists {
+				if setVal, ok := value.(*schema.Set); ok && setVal.Len() > 0 {
+					return fmt.Errorf("in 'jamfpro_macos_configuration_profile_plist.%s': when 'all_jss_users' scope is set to true, '%s' should not be set", resourceName, field)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
# Pull Request Description

## Summary
validator was still expecting a list, data model has been moved to a set. 

### Issue Reference
fixes issues #691 

### Motivation and Context
- Why is this change needed?
- What problem does it solve?
- If it fixes an open issue, please link to the issue here

### Dependencies
- List any dependencies that are required for this change
- Include any configuration changes needed
- Note any version updates required

## Type of Change
Please mark the relevant option with an `x`:
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Testing
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested this code in the following browsers/environments: [list environments]

## Quality Checklist
- [x] I have reviewed my own code before requesting review
- [ ] I have verified there are no other open Pull Requests for the same update/change
- [ ] All CI/CD pipelines pass without errors or warnings
- [x] My code follows the established style guidelines of this project
- [ ] My comments are used only when necessary, ideally where the codes purpose is not self explanatory (eg: necessary magic numbers)

## Screenshots/Recordings (if appropriate)
correctly now throws this error

![image](https://github.com/user-attachments/assets/bc272af7-9215-42f6-b590-2f1cb204822d)

