### PR TITLE
fix/userinitiatedenrollment

### DIFF
--- a/internal/resources/userinitiatedenrollment/resource.go
+++ b/internal/resources/userinitiatedenrollment/resource.go
@@ -607,7 +607,6 @@ func ResourceJamfProUserInitatedEnrollmentSettings() *schema.Resource {
 							Type:         schema.TypeString,
 							Required:     true,
 							Description:  "id of the Directory Service group to configure enrollment access for. Maps to request field 'groupId'",
-							ValidateFunc: validation.IsUUID,
 						},
 						"ldap_server_id": {
 							Type:        schema.TypeString,


### PR DESCRIPTION
# Pull Request Description

## Summary
Remove the UUID validation for `directory_service_group_id` attribute to allow the use of `-1` value (default group).

### Issue Reference
Fixes #[Issue Number]

### Motivation and Context
- Why is this change needed?
To allow management of the default group **All Directory Service Users** in **Settings > Global > User-initiated enrollment > Access**.
- What problem does it solve?
This default group is refered as `-1` and actually it doesn't pass the validation function that requires an UUID. 
- If it fixes an open issue, please link to the issue here
n/a 

### Dependencies
- List any dependencies that are required for this change
n/a 
- Include any configuration changes needed
n/a
- Note any version updates required
n/a

## Type of Change
Please mark the relevant option with an `x`:
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update (Wiki/README/Code comments)
- [ ] ♻️ Refactor (code improvement without functional changes)
- [ ] 🎨 Style update (formatting, renaming)
- [ ] 🔧 Configuration change
- [ ] 📦 Dependency update

## Testing
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added integration tests following the [testing implementation guide](../docs/testing-implementation.md)
- [ ] I have tested this code in the following browsers/environments: [list environments]

## Quality Checklist
- [ ] I have reviewed my own code before requesting review
- [ ] I have verified there are no other open Pull Requests for the same update/change
- [ ] All CI/CD pipelines pass without errors or warnings
- [ ] My code follows the established style guidelines of this project
- [ ] My comments are used only when necessary, ideally where the codes purpose is not self explanatory (eg: necessary magic numbers)
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have made corresponding changes to the README and other relevant documentation
- [ ] My changes generate no new warnings

## Screenshots/Recordings (if appropriate)
[Add screenshots or recordings that demonstrate the changes]

## Additional Notes
[Add any additional information that might be helpful for reviewers]