### PR TITLE
fix: Redaction logic can now handle nested structs

### DIFF
--- a/internal/resources/common/serialize_and_redact.go
+++ b/internal/resources/common/serialize_and_redact.go
@@ -8,9 +8,68 @@ import (
 	"fmt"
 	"reflect"
 	"strconv"
+	"strings"
+	"log"
 )
 
+// navigateToField recursively navigates through nested struct fields using dot notation
+// Returns the reflect.Value of the final field and whether it was found
+func navigateToField(v reflect.Value, fieldPath string) (reflect.Value, bool) {
+	if fieldPath == "" {
+		return reflect.Value{}, false
+	}
+
+	parts := strings.Split(fieldPath, ".")
+	return navigateToFieldRecursive(v, parts)
+}
+
+// navigateToFieldRecursive is the recursive helper function that walks the dot path
+func navigateToFieldRecursive(current reflect.Value, parts []string) (reflect.Value, bool) {
+	if len(parts) == 0 {
+		return current, true
+	}
+
+	// Dereference pointer
+	if current.Kind() == reflect.Ptr {
+		if current.IsNil() {
+			return reflect.Value{}, false
+		}
+		current = current.Elem()
+	}
+
+	if current.Kind() != reflect.Struct {
+		return reflect.Value{}, false
+	}
+
+	fieldName := parts[0]
+	field := current.FieldByName(fieldName)
+
+	if !field.IsValid() {
+		return reflect.Value{}, false
+	}
+
+	// Recursive case: navigate to the next level with remaining parts
+	return navigateToFieldRecursive(field, parts[1:])
+}
+
+// redactField redacts a single field based on its type
+func redactField(field reflect.Value, fieldPath string) {
+	if !field.CanSet() {
+		log.Printf("[DEBUG] Cannot set field '%s' - not settable", fieldPath)
+		return
+	}
+
+	if field.Kind() == reflect.String {
+		field.SetString("***REDACTED***")
+		log.Printf("[DEBUG] REDACTED: String field '%s' redacted", fieldPath)
+	} else {
+		log.Printf("[DEBUG] REDACTED: Field '%s' zeroed in output", fieldPath)
+		field.Set(reflect.Zero(field.Type()))
+	}
+}
+
 // SerializeAndRedactXML serializes a resource to XML and redacts specified fields.
+// Supports nested field paths using dot notation (e.g Parent.Child.Grandchild)
 func SerializeAndRedactXML(resource interface{}, redactFields []string) (string, error) {
 	v := reflect.ValueOf(resource)
 	if v.Kind() != reflect.Ptr || v.Elem().Kind() != reflect.Struct {
@@ -20,11 +79,11 @@ func SerializeAndRedactXML(resource interface{}, redactFields []string) (string,
 	resourceCopy := reflect.New(v.Elem().Type()).Elem()
 	resourceCopy.Set(v.Elem())
 
-	for _, field := range redactFields {
-		if f := resourceCopy.FieldByName(field); f.IsValid() && f.CanSet() {
-			if f.Kind() == reflect.String {
-				f.SetString("***REDACTED***")
-			}
+	for _, fieldPath := range redactFields {
+		if field, found := navigateToField(resourceCopy, fieldPath); found {
+			redactField(field, fieldPath)
+		} else {
+			log.Printf("[DEBUG] Field path '%s' not found or not accessible", fieldPath)
 		}
 	}
 
@@ -36,6 +95,7 @@ func SerializeAndRedactXML(resource interface{}, redactFields []string) (string,
 }
 
 // SerializeAndRedactJSON serializes a resource to JSON and redacts specified fields.
+// Supports nested field paths using dot notation (e.g., "Kitchen.Bowl.Fruit")
 func SerializeAndRedactJSON(resource interface{}, redactFields []string) (string, error) {
 	v := reflect.ValueOf(resource)
 	if v.Kind() != reflect.Ptr || v.Elem().Kind() != reflect.Struct {
@@ -45,11 +105,11 @@ func SerializeAndRedactJSON(resource interface{}, redactFields []string) (string
 	resourceCopy := reflect.New(v.Elem().Type()).Elem()
 	resourceCopy.Set(v.Elem())
 
-	for _, field := range redactFields {
-		if f := resourceCopy.FieldByName(field); f.IsValid() && f.CanSet() {
-			if f.Kind() == reflect.String {
-				f.SetString("***REDACTED***")
-			}
+	for _, fieldPath := range redactFields {
+		if field, found := navigateToField(resourceCopy, fieldPath); found {
+			redactField(field, fieldPath)
+		} else {
+			log.Printf("[DEBUG] Field path '%s' not found or not accessible", fieldPath)
 		}
 	}
 

--- a/internal/resources/common/serialize_and_redact_test.go
+++ b/internal/resources/common/serialize_and_redact_test.go
@@ -1,0 +1,369 @@
+package common
+
+import (
+	"encoding/json"
+	"encoding/xml"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// Test structs for various scenarios
+type TestStruct struct {
+	Name     string
+	Password string
+	Age      int
+	Nested   *NestedStruct
+	Direct   NestedStruct
+}
+
+type NestedStruct struct {
+	Secret     string
+	Token      string
+	Value      int
+	DeepNest   *DeepNestedStruct
+	DeepDirect DeepNestedStruct
+}
+
+type DeepNestedStruct struct {
+	HiddenField string
+	PublicField string
+	Number      int
+}
+
+func TestNavigateToField(t *testing.T) {
+	// Setup test data
+	testData := &TestStruct{
+		Name:     "John",
+		Password: "secret123",
+		Age:      30,
+		Nested: &NestedStruct{
+			Secret: "nested-secret",
+			Token:  "auth-token",
+			Value:  42,
+			DeepNest: &DeepNestedStruct{
+				HiddenField: "deep-secret",
+				PublicField: "public-info",
+				Number:      100,
+			},
+			DeepDirect: DeepNestedStruct{
+				HiddenField: "direct-deep-secret",
+				PublicField: "direct-public-info",
+				Number:      200,
+			},
+		},
+		Direct: NestedStruct{
+			Secret: "direct-secret",
+			Token:  "direct-token",
+			Value:  99,
+		},
+	}
+
+	tests := []struct {
+		name        string
+		fieldPath   string
+		expectFound bool
+		expectValue interface{}
+	}{
+		{
+			name:        "Simple field access",
+			fieldPath:   "Name",
+			expectFound: true,
+			expectValue: "John",
+		},
+		{
+			name:        "Simple field access - Password",
+			fieldPath:   "Password",
+			expectFound: true,
+			expectValue: "secret123",
+		},
+		{
+			name:        "Nested pointer field",
+			fieldPath:   "Nested.Secret",
+			expectFound: true,
+			expectValue: "nested-secret",
+		},
+		{
+			name:        "Nested pointer field - Token",
+			fieldPath:   "Nested.Token",
+			expectFound: true,
+			expectValue: "auth-token",
+		},
+		{
+			name:        "Deep nested pointer field",
+			fieldPath:   "Nested.DeepNest.HiddenField",
+			expectFound: true,
+			expectValue: "deep-secret",
+		},
+		{
+			name:        "Deep nested direct field",
+			fieldPath:   "Nested.DeepDirect.HiddenField",
+			expectFound: true,
+			expectValue: "direct-deep-secret",
+		},
+		{
+			name:        "Direct nested field",
+			fieldPath:   "Direct.Secret",
+			expectFound: true,
+			expectValue: "direct-secret",
+		},
+		{
+			name:        "Non-existent field",
+			fieldPath:   "NonExistent",
+			expectFound: false,
+			expectValue: nil,
+		},
+		{
+			name:        "Non-existent nested field",
+			fieldPath:   "Nested.NonExistent",
+			expectFound: false,
+			expectValue: nil,
+		},
+		{
+			name:        "Empty field path",
+			fieldPath:   "",
+			expectFound: false,
+			expectValue: nil,
+		},
+		{
+			name:        "Invalid path - too deep",
+			fieldPath:   "Name.Something",
+			expectFound: false,
+			expectValue: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := reflect.ValueOf(testData).Elem()
+			field, found := navigateToField(v, tt.fieldPath)
+
+			if found != tt.expectFound {
+				t.Errorf("navigateToField() found = %v, expectFound %v", found, tt.expectFound)
+				return
+			}
+
+			if tt.expectFound && field.Interface() != tt.expectValue {
+				t.Errorf("navigateToField() value = %v, expectValue %v", field.Interface(), tt.expectValue)
+			}
+		})
+	}
+}
+
+func TestNavigateToFieldWithNilPointer(t *testing.T) {
+	testData := &TestStruct{
+		Name:   "John",
+		Nested: nil, // nil pointer
+	}
+
+	v := reflect.ValueOf(testData).Elem()
+	_, found := navigateToField(v, "Nested.Secret")
+
+	if found {
+		t.Error("Expected navigateToField to return false for nil pointer navigation")
+	}
+}
+
+func TestSerializeAndRedactJSON(t *testing.T) {
+	testData := &TestStruct{
+		Name:     "John",
+		Password: "secret123",
+		Age:      30,
+		Nested: &NestedStruct{
+			Secret: "nested-secret",
+			Token:  "auth-token",
+			Value:  42,
+			DeepNest: &DeepNestedStruct{
+				HiddenField: "deep-secret",
+				PublicField: "public-info",
+				Number:      100,
+			},
+		},
+		Direct: NestedStruct{
+			Secret: "direct-secret",
+			Token:  "direct-token",
+			Value:  99,
+		},
+	}
+
+	redactFields := []string{
+		"Password",
+		"Nested.Secret",
+		"Nested.DeepNest.HiddenField",
+		"Direct.Token",
+		"Age", // Non-string field to test zeroing
+	}
+
+	result, err := SerializeAndRedactJSON(testData, redactFields)
+	if err != nil {
+		t.Fatalf("SerializeAndRedactJSON() error = %v", err)
+	}
+
+	// Parse the result back to verify redaction
+	var resultMap map[string]interface{}
+	if err := json.Unmarshal([]byte(result), &resultMap); err != nil {
+		t.Fatalf("Failed to parse JSON result: %v", err)
+	}
+
+	// Check that string fields were redacted
+	if resultMap["Password"] != "***REDACTED***" {
+		t.Errorf("Expected Password to be redacted, got: %v", resultMap["Password"])
+	}
+
+	// Check nested redaction
+	nested := resultMap["Nested"].(map[string]interface{})
+	if nested["Secret"] != "***REDACTED***" {
+		t.Errorf("Expected Nested.Secret to be redacted, got: %v", nested["Secret"])
+	}
+
+	// Check that non-redacted fields remain
+	if resultMap["Name"] != "John" {
+		t.Errorf("Expected Name to remain unchanged, got: %v", resultMap["Name"])
+	}
+
+	// Check that non-string field was zeroed
+	if resultMap["Age"] != float64(0) { // JSON unmarshals numbers as float64
+		t.Errorf("Expected Age to be zeroed, got: %v", resultMap["Age"])
+	}
+
+	// Check that Token in nested field was redacted but Value remains
+	if nested["Token"] != "auth-token" {
+		t.Errorf("Expected Nested.Token to remain unchanged, got: %v", nested["Token"])
+	}
+}
+
+func TestSerializeAndRedactXML(t *testing.T) {
+	testData := &TestStruct{
+		Name:     "John",
+		Password: "secret123",
+		Age:      30,
+		Nested: &NestedStruct{
+			Secret: "nested-secret",
+			Token:  "auth-token",
+			Value:  42,
+		},
+	}
+
+	redactFields := []string{
+		"Password",
+		"Nested.Secret",
+	}
+
+	result, err := SerializeAndRedactXML(testData, redactFields)
+	if err != nil {
+		t.Fatalf("SerializeAndRedactXML() error = %v", err)
+	}
+
+	// Check that the result contains redacted values
+	if !strings.Contains(result, "***REDACTED***") {
+		t.Error("Expected XML to contain redacted values")
+	}
+
+	// Check that non-redacted values remain
+	if !strings.Contains(result, "John") {
+		t.Error("Expected XML to contain non-redacted name")
+	}
+
+	// Parse back to verify structure
+	var resultStruct TestStruct
+	if err := xml.Unmarshal([]byte(result), &resultStruct); err != nil {
+		t.Fatalf("Failed to parse XML result: %v", err)
+	}
+
+	if resultStruct.Password != "***REDACTED***" {
+		t.Errorf("Expected Password to be redacted in XML, got: %v", resultStruct.Password)
+	}
+
+	if resultStruct.Name != "John" {
+		t.Errorf("Expected Name to remain unchanged in XML, got: %v", resultStruct.Name)
+	}
+}
+
+func TestSerializeAndRedactJSONInvalidInput(t *testing.T) {
+	// Test with non-pointer input
+	testData := TestStruct{Name: "John"}
+	_, err := SerializeAndRedactJSON(testData, []string{"Name"})
+	if err == nil {
+		t.Error("Expected error for non-pointer input")
+	}
+
+	// Test with nil pointer
+	var nilData *TestStruct
+	_, err = SerializeAndRedactJSON(nilData, []string{"Name"})
+	if err == nil {
+		t.Error("Expected error for nil pointer input")
+	}
+
+	// Test with pointer to non-struct
+	stringPtr := "test"
+	_, err = SerializeAndRedactJSON(&stringPtr, []string{})
+	if err == nil {
+		t.Error("Expected error for pointer to non-struct")
+	}
+}
+
+func TestSerializeAndRedactXMLInvalidInput(t *testing.T) {
+	// Test with non-pointer input
+	testData := TestStruct{Name: "John"}
+	_, err := SerializeAndRedactXML(testData, []string{"Name"})
+	if err == nil {
+		t.Error("Expected error for non-pointer input")
+	}
+}
+
+func TestRedactFieldWithNonSettableField(t *testing.T) {
+	// This test verifies the behavior when trying to redact a non-settable field
+	// In practice, this would be logged but not cause a panic
+	testData := &TestStruct{Name: "John"}
+	v := reflect.ValueOf(testData).Elem()
+	nameField := v.FieldByName("Name")
+
+	// Make field non-settable by getting it through Interface() and back
+	nonSettableField := reflect.ValueOf(nameField.Interface())
+
+	// This should not panic and should log a debug message
+	redactField(nonSettableField, "TestField")
+
+	// Original field should remain unchanged since we used a copy
+	if testData.Name != "John" {
+		t.Error("Original field should not be modified when using non-settable copy")
+	}
+}
+
+func BenchmarkNavigateToField(b *testing.B) {
+	testData := &TestStruct{
+		Name: "John",
+		Nested: &NestedStruct{
+			DeepNest: &DeepNestedStruct{
+				HiddenField: "deep-secret",
+			},
+		},
+	}
+
+	v := reflect.ValueOf(testData).Elem()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		navigateToField(v, "Nested.DeepNest.HiddenField")
+	}
+}
+
+func BenchmarkSerializeAndRedactJSON(b *testing.B) {
+	testData := &TestStruct{
+		Name:     "John",
+		Password: "secret123",
+		Nested: &NestedStruct{
+			Secret: "nested-secret",
+			DeepNest: &DeepNestedStruct{
+				HiddenField: "deep-secret",
+			},
+		},
+	}
+
+	redactFields := []string{"Password", "Nested.Secret", "Nested.DeepNest.HiddenField"}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		SerializeAndRedactJSON(testData, redactFields)
+	}
+}

--- a/internal/resources/computer_prestage_enrollment/constructor.go
+++ b/internal/resources/computer_prestage_enrollment/constructor.go
@@ -2,11 +2,11 @@
 package computer_prestage_enrollment
 
 import (
-	"encoding/json"
 	"fmt"
 	"log"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+	"github.com/deploymenttheory/terraform-provider-jamfpro/internal/resources/common"
 	"github.com/deploymenttheory/terraform-provider-jamfpro/internal/resources/common/constructors"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -126,7 +126,7 @@ func construct(d *schema.ResourceData, isUpdate bool) (*jamfpro.ResourceComputer
 	}
 
 	// Serialize and pretty-print the inventory collection object as JSON for logging
-	resourceJSON, err := json.MarshalIndent(resource, "", "  ")
+	resourceJSON, err := common.SerializeAndRedactJSON(resource, []string{"AccountSettings.AdminPassword", "AccountSettings.AdminUsername"})
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal Jamf Pro Computer Prestage to JSON: %v", err)
 	}


### PR DESCRIPTION
# Pull Request Description

## Summary
Redaction logic could before only handle keys which were one level deep. Now it can handle nested structs.

### Issue Reference

### Motivation and Context
- Why is this change needed?
Some resources were not redacted due to this missing functionality
- What problem does it solve?
Redacting individual keys in nested structs
- If it fixes an open issue, please link to the issue here

### Dependencies
- List any dependencies that are required for this change
- Include any configuration changes needed
- Note any version updates required



## Type of Change
Please mark the relevant option with an `x`:
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update (Wiki/README/Code comments)
- [ ] ♻️ Refactor (code improvement without functional changes)
- [ ] 🎨 Style update (formatting, renaming)
- [ ] 🔧 Configuration change
- [ ] 📦 Dependency update

## Testing
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added integration tests following the [testing implementation guide](../docs/testing-implementation.md)
- [x] I have tested this code in the following browsers/environments: [list environments]

## Quality Checklist
- [x] I have reviewed my own code before requesting review
- [x] I have verified there are no other open Pull Requests for the same update/change
- [ ] All CI/CD pipelines pass without errors or warnings
- [x] My code follows the established style guidelines of this project
- [x] My comments are used only when necessary, ideally where the codes purpose is not self explanatory (eg: necessary magic numbers)
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have made corresponding changes to the README and other relevant documentation
- [ ] My changes generate no new warnings

## Screenshots/Recordings (if appropriate)
<img width="579" height="473" alt="image" src="https://github.com/user-attachments/assets/89472e80-176b-4614-bbe9-46df0ae8e370" />

## Additional Notes
[Add any additional information that might be helpful for reviewers]