### PR TITLE
fix: Conform inventory_display_type default to API

### DIFF
--- a/internal/resources/computer_extension_attribute/resource.go
+++ b/internal/resources/computer_extension_attribute/resource.go
@@ -64,7 +64,7 @@ func ResourceJamfProComputerExtensionAttributes() *schema.Resource {
 			"inventory_display_type": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				Default:      "Extension Attributes",
+				Default:      "EXTENSION_ATTRIBUTES",
 				Description:  "Category in which to display the extension attribute in Jamf Pro.",
 				ValidateFunc: validation.StringInSlice([]string{"GENERAL", "HARDWARE", "OPERATING_SYSTEM", "USER_AND_LOCATION", "PURCHASING", "EXTENSION_ATTRIBUTES"}, false),
 			},

--- a/testing/payloads/jamfpro_computer_extension_attribute/computer_extension_attributes.tf
+++ b/testing/payloads/jamfpro_computer_extension_attribute/computer_extension_attributes.tf
@@ -39,6 +39,13 @@ resource "jamfpro_computer_extension_attribute" "jamfpro_computer_extension_attr
   ldap_extension_attribute_allowed = false
 }
 
+// Test that minimally defined object is sufficient
+resource "jamfpro_computer_extension_attribute" "jamfpro_computer_extension_attribute_minimum" {
+  name                             = "tf-testing-${var.testing_id}-min-test"
+  enabled                          = true
+  input_type                       = "TEXT"
+}
+
 // ========================================================================== //
 // Multiple extension attributes
 


### PR DESCRIPTION
# Conform default for `inventory_display_type` on `computer_extension_attribute`

## Summary
Jamf 11.18 won't accept a `computer_extension_attribute` with the default `inventory_display_type` of "Extension Attributes", it only works with `EXTENSION_ATTRIBUTES`.

### Issue Reference
PR submitted in lieu of opening an issue.

## Type of Change
Please mark the relevant option with an `x`:
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update (Wiki/README/Code comments)
- [ ] ♻️ Refactor (code improvement without functional changes)
- [ ] 🎨 Style update (formatting, renaming)
- [ ] 🔧 Configuration change
- [ ] 📦 Dependency update

## Testing
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added integration tests following the [testing implementation guide](../docs/testing-implementation.md)
- [x] I have tested this code with and without the change, against Jamf 11.18

## Quality Checklist
- [x] I have reviewed my own code before requesting review
- [x] I have verified there are no other open Pull Requests for the same update/change
- [ ] All CI/CD pipelines pass without errors or warnings
- [x] My code follows the established style guidelines of this project
- [x] My comments are used only when necessary, ideally where the codes purpose is not self explanatory (eg: necessary magic numbers)
- [x] I have added necessary documentation (if appropriate)
- [x] I have made corresponding changes to the README and other relevant documentation
- [x] My changes generate no new warnings

## Additional Notes
First PR and first edit on a Terraform provider, so I may be missing a key step that I'm not aware of.

I don't know how to run these tests locally and I don't have a Jamf environment I can run robust unit tests against.
