### PR TITLE
feat: Improve advanced computer search schema with better validation and documentation

### DIFF
--- a/internal/resources/advanced_computer_search/resource.go
+++ b/internal/resources/advanced_computer_search/resource.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/deploymenttheory/terraform-provider-jamfpro/internal/resources/common/sharedschemas"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 // resourceJamfProAdvancedComputerSearches defines the schema for managing Advanced Computer Searches in Terraform.
@@ -57,45 +58,63 @@ func ResourceJamfProAdvancedComputerSearches() *schema.Resource {
 				Description: "Third sorting criteria for the advanced computer search",
 			},
 			"criteria": {
-				Type:     schema.TypeList,
-				Optional: true,
+				Type:        schema.TypeList,
+				Required:    true,
+				Description: "List of search criteria",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"name": {
-							Type:     schema.TypeString,
-							Required: true,
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "Name of the search criteria field",
 						},
 						"priority": {
-							Type:     schema.TypeInt,
-							Optional: true,
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Default:      0,
+							ValidateFunc: validation.IntBetween(0, 100),
+							Description:  "Priority order of the criteria. Default is 0, 0 is always used for the first criterion.",
 						},
 						"and_or": {
-							Type:     schema.TypeString,
-							Optional: true,
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice([]string{"and", "or"}, false),
+							Description:  "Logical operator (and/or) for the search criteria",
 						},
 						"search_type": {
 							Type:     schema.TypeString,
 							Required: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								"is", "is not", "like", "not like", "has", "does not have",
+								"greater than", "less than", "greater than or equal", "less than or equal",
+								"matches regex", "does not match regex", "member of", "not member of",
+								"more than x days ago",
+							}, false),
+							Description: "Type of search to perform",
 						},
 						"value": {
-							Type:     schema.TypeString,
-							Required: true,
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
+							Description:  "Value to search for",
 						},
 						"opening_paren": {
-							Type:     schema.TypeBool,
-							Optional: true,
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Description: "Whether this criterion has an opening parenthesis",
 						},
 						"closing_paren": {
-							Type:     schema.TypeBool,
-							Optional: true,
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Description: "Whether this criterion has a closing parenthesis",
 						},
 					},
 				},
 			},
 			"display_fields": {
-				Type:        schema.TypeList,
-				Description: "List of displayfields",
+				Type:        schema.TypeSet, // Use TypeSet instead of TypeList as jamf uses a random order for the fields
 				Optional:    true,
+				Description: "List of fields to display in the search results",
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},

--- a/internal/resources/advanced_mobile_device_search/resource.go
+++ b/internal/resources/advanced_mobile_device_search/resource.go
@@ -72,6 +72,7 @@ func ResourceJamfProAdvancedMobileDeviceSearches() *schema.Resource {
 								"is", "is not", "like", "not like", "has", "does not have",
 								"greater than", "less than", "greater than or equal", "less than or equal",
 								"matches regex", "does not match regex", "member of", "not member of",
+								"more than x days ago",
 							}, false),
 							Description: "Type of search to perform",
 						},


### PR DESCRIPTION
# Pull Request Description

## Summary
This adds the validation features which were already included in Advanced Mobile Device Search to Advanced Computer Search as well as an additional `search_type` to Advanced Mobile Device Search.

### Motivation and Context
- Why is this change needed?
     - At the bare minimum, the `search_type` needs added to Advanced Mobile Device Search as it's a valid option. While digging into why this issue existed for Mobile Devices and not Computers, I noted that Mobile Devices had much more validation done to the input than Computers. In an effort to standardize, these features were also added to Computers.
- What problem does it solve?
     - This helps ensure Advanced Searches of both types are using valid input schemas. 

## Type of Change
Please mark the relevant option with an `x`:
- [X] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update (Wiki/README/Code comments)
- [ ] ♻️ Refactor (code improvement without functional changes)
- [ ] 🎨 Style update (formatting, renaming)
- [ ] 🔧 Configuration change
- [ ] 📦 Dependency update

## Testing
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] I have added integration tests following the [testing implementation guide](../docs/testing-implementation.md)
- [ ] I have tested this code in the following browsers/environments: [list environments]

## Quality Checklist
- [X] I have reviewed my own code before requesting review
- [X] I have verified there are no other open Pull Requests for the same update/change
- [ ] All CI/CD pipelines pass without errors or warnings
- [X] My code follows the established style guidelines of this project
- [X] My comments are used only when necessary, ideally where the codes purpose is not self explanatory (eg: necessary magic numbers)
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have made corresponding changes to the README and other relevant documentation
- [ ] My changes generate no new warnings

## Additional Notes
**NOTE**: I do not know if this is a fully comprehensive list of `search_type` operators. Additional changes may be necessary after the fact to add more or it might be desired to remove this validation from both Advanced Searches.