### PR TITLE
Fix nil pointer dereference when upgrading from v0.23.0

### DIFF
--- a/internal/services/computer_prestage_enrollment/resource_state.go
+++ b/internal/services/computer_prestage_enrollment/resource_state.go
@@ -152,32 +152,46 @@ func updateState(d *schema.ResourceData, resp *jamfpro.ResourceComputerPrestage)
 
 // skipSetupItems converts the ComputerPrestageSubsetSkipSetupItems struct to a map
 func skipSetupItems(skipSetupItems jamfpro.ComputerPrestageSubsetSkipSetupItems) map[string]any {
-	return map[string]any{
-		"biometric":                   *skipSetupItems.Biometric,
-		"terms_of_address":            *skipSetupItems.TermsOfAddress,
-		"file_vault":                  *skipSetupItems.FileVault,
-		"icloud_diagnostics":          *skipSetupItems.ICloudDiagnostics,
-		"diagnostics":                 *skipSetupItems.Diagnostics,
-		"accessibility":               *skipSetupItems.Accessibility,
-		"apple_id":                    *skipSetupItems.AppleID,
-		"screen_time":                 *skipSetupItems.ScreenTime,
-		"siri":                        *skipSetupItems.Siri,
-		"display_tone":                *skipSetupItems.DisplayTone,
-		"restore":                     *skipSetupItems.Restore,
-		"appearance":                  *skipSetupItems.Appearance,
-		"privacy":                     *skipSetupItems.Privacy,
-		"payment":                     *skipSetupItems.Payment,
-		"registration":                *skipSetupItems.Registration,
-		"tos":                         *skipSetupItems.TOS,
-		"icloud_storage":              *skipSetupItems.ICloudStorage,
-		"location":                    *skipSetupItems.Location,
-		"intelligence":                *skipSetupItems.Intelligence,
-		"enable_lockdown_mode":        *skipSetupItems.EnableLockdownMode,
-		"welcome":                     *skipSetupItems.Welcome,
-		"wallpaper":                   *skipSetupItems.Wallpaper,
-		"software_update":             *skipSetupItems.SoftwareUpdate,
-		"additional_privacy_settings": *skipSetupItems.AdditionalPrivacySettings,
+	result := map[string]any{
+		"biometric":          *skipSetupItems.Biometric,
+		"terms_of_address":   *skipSetupItems.TermsOfAddress,
+		"file_vault":         *skipSetupItems.FileVault,
+		"icloud_diagnostics": *skipSetupItems.ICloudDiagnostics,
+		"diagnostics":        *skipSetupItems.Diagnostics,
+		"accessibility":      *skipSetupItems.Accessibility,
+		"apple_id":           *skipSetupItems.AppleID,
+		"screen_time":        *skipSetupItems.ScreenTime,
+		"siri":               *skipSetupItems.Siri,
+		"display_tone":       *skipSetupItems.DisplayTone,
+		"restore":            *skipSetupItems.Restore,
+		"appearance":         *skipSetupItems.Appearance,
+		"privacy":            *skipSetupItems.Privacy,
+		"payment":            *skipSetupItems.Payment,
+		"registration":       *skipSetupItems.Registration,
+		"tos":                *skipSetupItems.TOS,
+		"icloud_storage":     *skipSetupItems.ICloudStorage,
+		"location":           *skipSetupItems.Location,
+		"intelligence":       *skipSetupItems.Intelligence,
+		"enable_lockdown_mode": *skipSetupItems.EnableLockdownMode,
+		"welcome":              *skipSetupItems.Welcome,
+		"wallpaper":            *skipSetupItems.Wallpaper,
 	}
+
+	// Handle fields added in v0.25.0 (Jamf Pro 11.20) that may not exist in older state
+	// Default to false if nil to maintain backward compatibility
+	if skipSetupItems.SoftwareUpdate != nil {
+		result["software_update"] = *skipSetupItems.SoftwareUpdate
+	} else {
+		result["software_update"] = false
+	}
+
+	if skipSetupItems.AdditionalPrivacySettings != nil {
+		result["additional_privacy_settings"] = *skipSetupItems.AdditionalPrivacySettings
+	} else {
+		result["additional_privacy_settings"] = false
+	}
+
+	return result
 }
 
 // getHCLValue gets the value of a key from the ResourceData, either from the current state or the config.

--- a/internal/services/computer_prestage_enrollment/resource_state_test.go
+++ b/internal/services/computer_prestage_enrollment/resource_state_test.go
@@ -1,0 +1,106 @@
+package computer_prestage_enrollment
+
+import (
+	"testing"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+// TestSkipSetupItems_NilPointers tests that skipSetupItems handles nil pointers gracefully
+// This addresses the bug where upgrading from v0.23.0 would crash when SoftwareUpdate and
+// AdditionalPrivacySettings fields were nil in existing state.
+func TestSkipSetupItems_NilPointers(t *testing.T) {
+	// Simulate state from v0.23.0 where new fields don't exist (nil pointers)
+	skipSetupItemsOldState := jamfpro.ComputerPrestageSubsetSkipSetupItems{
+		Biometric:         boolPtr(true),
+		TermsOfAddress:    boolPtr(false),
+		FileVault:         boolPtr(false),
+		ICloudDiagnostics: boolPtr(true),
+		Diagnostics:       boolPtr(true),
+		Accessibility:     boolPtr(false),
+		AppleID:           boolPtr(true),
+		ScreenTime:        boolPtr(true),
+		Siri:              boolPtr(true),
+		DisplayTone:       boolPtr(false),
+		Restore:           boolPtr(true),
+		Appearance:        boolPtr(true),
+		Privacy:           boolPtr(true),
+		Payment:           boolPtr(true),
+		Registration:      boolPtr(true),
+		TOS:               boolPtr(true),
+		ICloudStorage:     boolPtr(true),
+		Location:          boolPtr(true),
+		Intelligence:      boolPtr(true),
+		EnableLockdownMode: boolPtr(true),
+		Welcome:           boolPtr(true),
+		Wallpaper:         boolPtr(true),
+		// SoftwareUpdate and AdditionalPrivacySettings are nil (as they would be in v0.23.0 state)
+		SoftwareUpdate:            nil,
+		AdditionalPrivacySettings: nil,
+	}
+
+	// This should not panic
+	result := skipSetupItems(skipSetupItemsOldState)
+
+	// Verify the new fields default to false when nil
+	if softwareUpdate, ok := result["software_update"].(bool); !ok || softwareUpdate != false {
+		t.Errorf("Expected software_update to be false when nil, got %v", result["software_update"])
+	}
+
+	if additionalPrivacy, ok := result["additional_privacy_settings"].(bool); !ok || additionalPrivacy != false {
+		t.Errorf("Expected additional_privacy_settings to be false when nil, got %v", result["additional_privacy_settings"])
+	}
+
+	// Verify old fields still work correctly
+	if biometric, ok := result["biometric"].(bool); !ok || biometric != true {
+		t.Errorf("Expected biometric to be true, got %v", result["biometric"])
+	}
+}
+
+// TestSkipSetupItems_WithNewFields tests that skipSetupItems works correctly with all fields present
+func TestSkipSetupItems_WithNewFields(t *testing.T) {
+	// Simulate state from v0.25.0+ where all fields exist
+	skipSetupItemsNewState := jamfpro.ComputerPrestageSubsetSkipSetupItems{
+		Biometric:                 boolPtr(true),
+		TermsOfAddress:            boolPtr(false),
+		FileVault:                 boolPtr(false),
+		ICloudDiagnostics:         boolPtr(true),
+		Diagnostics:               boolPtr(true),
+		Accessibility:             boolPtr(false),
+		AppleID:                   boolPtr(true),
+		ScreenTime:                boolPtr(true),
+		Siri:                      boolPtr(true),
+		DisplayTone:               boolPtr(false),
+		Restore:                   boolPtr(true),
+		Appearance:                boolPtr(true),
+		Privacy:                   boolPtr(true),
+		Payment:                   boolPtr(true),
+		Registration:              boolPtr(true),
+		TOS:                       boolPtr(true),
+		ICloudStorage:             boolPtr(true),
+		Location:                  boolPtr(true),
+		Intelligence:              boolPtr(true),
+		EnableLockdownMode:        boolPtr(true),
+		Welcome:                   boolPtr(true),
+		Wallpaper:                 boolPtr(true),
+		SoftwareUpdate:            boolPtr(true),
+		AdditionalPrivacySettings: boolPtr(false),
+	}
+
+	result := skipSetupItems(skipSetupItemsNewState)
+
+	// Verify the new fields work correctly when not nil
+	if softwareUpdate, ok := result["software_update"].(bool); !ok || softwareUpdate != true {
+		t.Errorf("Expected software_update to be true, got %v", result["software_update"])
+	}
+
+	if additionalPrivacy, ok := result["additional_privacy_settings"].(bool); !ok || additionalPrivacy != false {
+		t.Errorf("Expected additional_privacy_settings to be false, got %v", result["additional_privacy_settings"])
+	}
+}
+
+// boolPtr is a helper function to get a pointer to a bool value
+func boolPtr(b bool) *bool {
+	return &b
+}
+


### PR DESCRIPTION
## Description

Fixes a critical bug where the provider crashes with a nil pointer dereference when upgrading from v0.23.0 to any version v0.24.0 or later.

## Problem

The `skipSetupItems()` function in `resource_state.go` unconditionally dereferences pointers for `software_update` and `additional_privacy_settings` fields (added in v0.25.0 for Jamf Pro 11.20 support). When reading state from v0.23.0 or earlier, these pointers are nil, causing a panic:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xf889c0]

goroutine 437 [running]:
github.com/deploymenttheory/terraform-provider-jamfpro/internal/services/computer_prestage_enrollment.skipSetupItems(...)
    internal/services/computer_prestage_enrollment/resource_state.go:179
```

This blocks ALL users on v0.23.0 or earlier from upgrading without manual state manipulation.

## Solution

Added nil pointer checks for the new fields with sensible defaults:
- Check if `SoftwareUpdate` pointer is nil before dereferencing
- Check if `AdditionalPrivacySettings` pointer is nil before dereferencing  
- Default both to `false` if nil to maintain backward compatibility

## Testing

Added comprehensive unit tests that verify:
1. ✅ Function handles nil pointers gracefully (v0.23.0 state)
2. ✅ Function works correctly with all fields present (v0.25.0+ state)
3. ✅ Both tests pass

## Impact

- **Before**: Provider crashes on any upgrade from v0.23.0, requiring manual state intervention
- **After**: Seamless upgrades from v0.23.0 to any later version

## Related

Fixes #919

## Checklist

- [x] Code changes tested with unit tests
- [x] Unit tests pass locally
- [x] Backwards compatible (defaults to false for nil values)
- [x] No breaking changes to existing functionality