### PR TITLE
fix: Mark icon file attributes as ForceNew

### DIFF
--- a/internal/services/icon/resource_schema.go
+++ b/internal/services/icon/resource_schema.go
@@ -14,7 +14,6 @@ func ResourceJamfProIcons() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: create,
 		ReadContext:   readWithCleanup,
-		UpdateContext: update,
 		DeleteContext: delete,
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(70 * time.Second),
@@ -44,6 +43,7 @@ func ResourceJamfProIcons() *schema.Resource {
 				Type:             schema.TypeString,
 				Optional:         true,
 				Default:          "",
+				ForceNew:         true,
 				Description:      "The file path to the icon file (PNG) to be uploaded.",
 				ValidateDiagFunc: validateIconFilePath(),
 			},
@@ -51,6 +51,7 @@ func ResourceJamfProIcons() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Default:      "",
+				ForceNew:     true,
 				Description:  "The web location of the icon file, can be a http(s) URL",
 				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^(http|https|file)://.*$|^(/|./|../).*$`), "Must be a valid URL."),
 			},
@@ -58,6 +59,7 @@ func ResourceJamfProIcons() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Default:     "",
+				ForceNew:    true,
 				Sensitive:   true,
 				Description: "Base64 encoded string of the icon image file (PNG format). Must be a valid base64 encoded image.",
 			},


### PR DESCRIPTION
# Pull Request Description

## Summary
Mark icon file attributes (`icon_file_path`, `icon_file_web_source`, `icon_file_base64`) as `ForceNew` to properly handle API behavior where uploading a new icon generates a new ID. Remove the `UpdateContext` handler since these attributes cannot be updated in-place.

### Issue Reference
No existing issue

### Motivation and Context
When icon file attributes change, the Jamf Pro API generates a new icon with a new ID rather than updating the existing icon in-place. Previously, the provider attempted to update the icon, which caused the API to return a new ID while Terraform's state still referenced the old ID. This resulted in state consolidation failures during apply.

By marking these attributes as `ForceNew`, Terraform will properly show a destroy-then-create operation in the plan, which accurately reflects the API's behavior and prevents state conflicts.

### Dependencies
None

## Type of Change
Please mark the relevant option with an `x`:
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update (Wiki/README/Code comments)
- [ ] ♻️ Refactor (code improvement without functional changes)
- [ ] 🎨 Style update (formatting, renaming)
- [ ] 🔧 Configuration change
- [ ] 📦 Dependency update

## Testing
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added integration tests following the [testing implementation guide](../docs/testing-implementation.md)
- [x] I have tested this code in the following browsers/environments: Local testing with modified provider against live Jamf Pro instances running 11.21.1 and 11.23.0-b.1

The existing payload test (`testing/payloads/jamfpro_icon/jamfpro_icon.tf`) continues to work correctly. The fix was verified by modifying the icon URL and confirming the plan shows destroy-then-create (`-/+`) behavior rather than in-place
 update (`~`).

## Quality Checklist
- [x] I have reviewed my own code before requesting review
- [x] I have verified there are no other open Pull Requests for the same update/change
- [x] All CI/CD pipelines pass without errors or warnings
- [x] My code follows the established style guidelines of this project
- [x] My comments are used only when necessary, ideally where the codes purpose is not self explanatory (eg: necessary magic numbers)
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have made corresponding changes to the README and other relevant documentation
- [x] My changes generate no new warnings

## Screenshots/Recordings (if appropriate)
N/A

## Additional Notes
This fix resolves state consolidation failures that occurred when icon file attributes were modified. The change aligns the provider's behavior with the actual Jamf Pro API, which generates new icon IDs on upload rather than updating
existing icons in-place.