### PR TITLE
feat: Add importer support for smtp_server resource

### DIFF
--- a/internal/services/smtp_server/resource_schema.go
+++ b/internal/services/smtp_server/resource_schema.go
@@ -14,6 +14,9 @@ func ResourceJamfProSMTPServer() *schema.Resource {
 		UpdateContext: update,
 		DeleteContext: delete,
 		CustomizeDiff: customDiff,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(1 * time.Minute),
 			Read:   schema.DefaultTimeout(1 * time.Minute),


### PR DESCRIPTION
# Pull Request Description

  ## Summary
  Add importer support for the `jamfpro_smtp_server` resource, enabling users to import existing SMTP server configurations from Jamf Pro into Terraform state.

  ### Issue Reference
  No issue reference

  ### Motivation and Context
  - The `jamfpro_smtp_server` resource was missing importer functionality
  - Users cannot currently import existing SMTP server configurations from their Jamf Pro instance into Terraform
  - This follows the established pattern used by other resources in the provider (account, webhook, app_installer, etc.)

  ### Dependencies
  - No new dependencies required
  - No configuration changes needed
  - No version updates required


  ## Type of Change
  Please mark the relevant option with an `x`:
  - [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
  - [x] ✨ New feature (non-breaking change which adds functionality)
  - [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] 📝 Documentation update (Wiki/README/Code comments)
  - [ ] ♻️ Refactor (code improvement without functional changes)
  - [ ] 🎨 Style update (formatting, renaming)
  - [ ] 🔧 Configuration change
  - [ ] 📦 Dependency update

  ## Testing
  - [ ] I have added unit tests that prove my fix is effective or that my feature works
  - [x] New and existing unit tests pass locally with my changes
  - [ ] I have added integration tests following the [testing implementation guide](../docs/testing-implementation.md)
  - [x] I have tested this code in the following browsers/environments: Local development environment

  ## Quality Checklist
  - [x] I have reviewed my own code before requesting review
  - [x] I have verified there are no other open Pull Requests for the same update/change
  - [] All CI/CD pipelines pass without errors or warnings
  - [x] My code follows the established style guidelines of this project
  - [x] My comments are used only when necessary, ideally where the codes purpose is not self explanatory (eg: necessary magic numbers)
  - [] I have added necessary documentation (if appropriate)
  - [ ] I have made corresponding changes to the README and other relevant documentation
  - [x] My changes generate no new warnings

  ## Screenshots/Recordings (if appropriate)
  N/A - Code-only change

  ## Additional Notes
  The implementation uses `schema.ImportStatePassthroughContext`, which is the standard pattern for singleton resources and is consistent with other importers in the provider codebase. This allows the resource ID to be passed directly to
  Terraform state during import.