### PR TITLE
fix: Initialize DisplayFields to empty slice in Advanced Mobile Device Search

### DIFF
--- a/internal/services/advanced_mobile_device_search/resource_constructor.go
+++ b/internal/services/advanced_mobile_device_search/resource_constructor.go
@@ -15,8 +15,9 @@ func construct(d *schema.ResourceData) (*jamfpro.ResourceAdvancedMobileDeviceSea
 	siteId := d.Get("site_id").(string)
 
 	resource := &jamfpro.ResourceAdvancedMobileDeviceSearch{
-		Name:   d.Get("name").(string),
-		SiteId: &siteId,
+		Name:           d.Get("name").(string),
+		SiteId:         &siteId,
+		DisplayFields:  []string{}, // Initialize to empty slice to avoid null in JSON
 	}
 
 	if v, ok := d.GetOk("criteria"); ok {


### PR DESCRIPTION
## Summary
  Initialize `DisplayFields` to an empty slice instead of leaving it uninitialized when not specified in Terraform configuration. This prevents the JAMF API from receiving a null value, which causes a NullPointerException.

  ### Issue Reference
  No open issue

  ### Motivation and Context
  When creating an advanced mobile device search resource without specifying `display_fields` in the Terraform configuration, the API returns a 400 error:
```
│ Error: failed to create Advanced Mobile Search 'Mobile Device Delinquent Inventory Report' after retries: failed to create advanced mobile device search, error: {"status_code":400,"method":"POST","url":"https://sjndatacentylerpyooy.jamfcloud.com/api/v1/advanced-mobile-device-searches","httpStatus":400,"errors":[{"code":"INVALID_FIELD","field":"displayFields","description":"Cannot invoke \"java.util.Collection.toArray()\" because \"c\" is null","id":"0"}],"message":"API Error Response","raw_response":""}
│
│   with module.sjndatacentylerpyooy.jamfpro_advanced_mobile_device_search.searches["Mobile Device Delinquent Inventory Report"],
│   on modules/jamfpro-server/mobile-device-searches.tf line 3, in resource "jamfpro_advanced_mobile_device_search" "searches":
│    3: resource "jamfpro_advanced_mobile_device_search" "searches" {
│
╵
```

  The JAMF API expects `DisplayFields` to be a non-null array (even if empty), but the current implementation leaves it as nil when the field is not configured, which serializes to `null` in the JSON request body.

  ### Dependencies
  - None

## Type of Change
Please mark the relevant option with an `x`:
- [X] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update (Wiki/README/Code comments)
- [ ] ♻️ Refactor (code improvement without functional changes)
- [ ] 🎨 Style update (formatting, renaming)
- [ ] 🔧 Configuration change
- [ ] 📦 Dependency update

## Testing
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] I have added integration tests following the [testing implementation guide](../docs/testing-implementation.md)
- [X] I have tested this code in the following browsers/environments: Jamf Pro Cloud Server running 11.22.1-t1762179835791 and 11.23.0-t1762956830760

## Quality Checklist
- [X] I have reviewed my own code before requesting review
- [X] I have verified there are no other open Pull Requests for the same update/change
- [ ] All CI/CD pipelines pass without errors or warnings
- [X] My code follows the established style guidelines of this project
- [X] My comments are used only when necessary, ideally where the codes purpose is not self explanatory (eg: necessary magic numbers)
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have made corresponding changes to the README and other relevant documentation
- [X] My changes generate no new warnings

## Screenshots/Recordings (if appropriate)
Working run with local dev environment:
```
╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - deploymenttheory/jamfpro in /Users/tyler.sparr/bin/plugins/registry.terraform.io/deploymenttheory/jamfpro
│
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵

OpenTofu used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

OpenTofu will perform the following actions:

  # module.encoretechnfr.jamfpro_advanced_mobile_device_search.searches["Mobile Device Delinquent Inventory Report"] will be created
  + resource "jamfpro_advanced_mobile_device_search" "searches" {
      + id      = (known after apply)
      + name    = "Mobile Device Delinquent Inventory Report"
      + site_id = "-1"

      + criteria {
          + and_or        = "and"
          + closing_paren = false
          + name          = "Last Inventory Update"
          + opening_paren = false
          + priority      = 0
          + search_type   = "more than x days ago"
          + value         = "15"
        }
      + criteria {
          + and_or        = "and"
          + closing_paren = false
          + name          = "Managed"
          + opening_paren = false
          + priority      = 1
          + search_type   = "is"
          + value         = "Managed"
        }
    }

  # module.sjndatacentylerpyooy.jamfpro_advanced_mobile_device_search.searches["Mobile Device Delinquent Inventory Report"] will be created
  + resource "jamfpro_advanced_mobile_device_search" "searches" {
      + id      = (known after apply)
      + name    = "Mobile Device Delinquent Inventory Report"
      + site_id = "-1"

      + criteria {
          + and_or        = "and"
          + closing_paren = false
          + name          = "Last Inventory Update"
          + opening_paren = false
          + priority      = 0
          + search_type   = "more than x days ago"
          + value         = "15"
        }
      + criteria {
          + and_or        = "and"
          + closing_paren = false
          + name          = "Managed"
          + opening_paren = false
          + priority      = 1
          + search_type   = "is"
          + value         = "Managed"
        }
    }

Plan: 2 to add, 0 to change, 0 to destroy.
```

```
module.sjndatacentylerpyooy.jamfpro_advanced_mobile_device_search.searches["Mobile Device Delinquent Inventory Report"]: Creating...
module.encoretechnfr.jamfpro_advanced_mobile_device_search.searches["Mobile Device Delinquent Inventory Report"]: Creating...
module.sjndatacentylerpyooy.jamfpro_advanced_mobile_device_search.searches["Mobile Device Delinquent Inventory Report"]: Creation complete after 0s [id=6]
module.encoretechnfr.jamfpro_advanced_mobile_device_search.searches["Mobile Device Delinquent Inventory Report"]: Creation complete after 1s [id=6]
```

## Additional Notes