### PR TITLE
fix: macos_configuration_profile_plist remove indentation from plist encoder when updating

### DIFF
--- a/internal/services/macos_configuration_profile_plist/resource_constructor.go
+++ b/internal/services/macos_configuration_profile_plist/resource_constructor.go
@@ -130,7 +130,6 @@ func constructJamfProMacOSConfigurationProfilePlist(d *schema.ResourceData, mode
 		// Encode the plist with injections
 
 		encoder := plist.NewEncoder(&buf)
-		encoder.Indent("    ")
 		if err := encoder.Encode(newPlist); err != nil {
 			return nil, fmt.Errorf("failed to encode plist payload with injected PayloadUUID and PayloadIdentifier: %v", err)
 		}


### PR DESCRIPTION
# Pull Request Description

## Summary
Removes the forced space indent conversion when updating profiles.

This makes no visible difference to profile content in the UI for custom payloads and fixes an issue where Associated Domains are removed by Jamf Pro when the payload uses space indents.

I also tried with the indent set to a tab instead of 4 spaces, which worked too. But just opted to remove it in the end. Please let me know if you'd prefer a tab instead - it doesn't seem to make a functional difference from what I can see but I could be missing something.

### Issue Reference
Fixes #933

### Motivation and Context
- Why is this change needed?
- What problem does it solve?
- If it fixes an open issue, please link to the issue here

### Dependencies
- List any dependencies that are required for this change
- Include any configuration changes needed
- Note any version updates required



## Type of Change
Please mark the relevant option with an `x`:
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update (Wiki/README/Code comments)
- [ ] ♻️ Refactor (code improvement without functional changes)
- [ ] 🎨 Style update (formatting, renaming)
- [ ] 🔧 Configuration change
- [ ] 📦 Dependency update

## Testing
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added integration tests following the [testing implementation guide](../docs/testing-implementation.md)
- [x] I have tested this code in the following browsers/environments: [list environments]

## Quality Checklist
- [x] I have reviewed my own code before requesting review
- [x] I have verified there are no other open Pull Requests for the same update/change
- [ ] All CI/CD pipelines pass without errors or warnings
- [x] My code follows the established style guidelines of this project
- [ ] My comments are used only when necessary, ideally where the codes purpose is not self explanatory (eg: necessary magic numbers)
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have made corresponding changes to the README and other relevant documentation
- [ ] My changes generate no new warnings

## Screenshots/Recordings (if appropriate)
[Add screenshots or recordings that demonstrate the changes]

## Additional Notes
[Add any additional information that might be helpful for reviewers]