### PR TITLE
fix: static_computer_group empty assigned_computer_ids empty list handling 

### DIFF
--- a/internal/services/static_computer_group/resource_constructor.go
+++ b/internal/services/static_computer_group/resource_constructor.go
@@ -20,15 +20,17 @@ func construct(d *schema.ResourceData) (*jamfpro.ResourceComputerGroup, error) {
 
 	resource.Site = sharedschemas.ConstructSharedResourceSite(d.Get("site_id").(int))
 
-	assignedComputers := d.Get("assigned_computer_ids").([]any)
-	if len(assignedComputers) > 0 {
-		computers := []jamfpro.ComputerGroupSubsetComputer{}
-		for _, v := range assignedComputers {
-			computers = append(computers, jamfpro.ComputerGroupSubsetComputer{
-				ID: v.(int),
-			})
+	if rawConfig := d.GetRawConfig(); !rawConfig.IsNull() {
+		if raw := rawConfig.GetAttr("assigned_computer_ids"); !raw.IsNull() {
+			assignedComputers := d.Get("assigned_computer_ids").([]any)
+			computers := []jamfpro.ComputerGroupSubsetComputer{}
+			for _, id := range assignedComputers {
+				computers = append(computers, jamfpro.ComputerGroupSubsetComputer{
+					ID: id.(int),
+				})
+			}
+			resource.Computers = &computers
 		}
-		resource.Computers = &computers
 	}
 
 	resourceXML, err := xml.MarshalIndent(resource, "", "  ")


### PR DESCRIPTION
# Pull Request Description

## Summary
This ensures we remove all assigned computers from a static group, if  `assigned_computer_ids = []` is declared. Before, this would always omit the `<computers>` field from the API request, and not remove members assigned to a group outside of Terraform, causing state drift. We still omit if the field is unset which is desirable and won't cause membership changes during updates if we're not declaring that field.

I'd like to follow up with a similar change to `static_mobile_device_groups` soon but this will need an SDK change too to make pointer usage consistent with computers. Currently that resource always clears out members, whether omitted or set `[]`.

### Issue Reference
Fixes #[Issue Number]

### Motivation and Context
- Why is this change needed?
- What problem does it solve?
- If it fixes an open issue, please link to the issue here

### Dependencies
- List any dependencies that are required for this change
- Include any configuration changes needed
- Note any version updates required



## Type of Change
Please mark the relevant option with an `x`:
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update (Wiki/README/Code comments)
- [ ] ♻️ Refactor (code improvement without functional changes)
- [ ] 🎨 Style update (formatting, renaming)
- [ ] 🔧 Configuration change
- [ ] 📦 Dependency update

## Testing
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added integration tests following the [testing implementation guide](../docs/testing-implementation.md)
- [x] I have tested this code in the following browsers/environments: local environment

## Quality Checklist
- [x] I have reviewed my own code before requesting review
- [x] I have verified there are no other open Pull Requests for the same update/change
- [ ] All CI/CD pipelines pass without errors or warnings
- [x] My code follows the established style guidelines of this project
- [x] My comments are used only when necessary, ideally where the codes purpose is not self explanatory (eg: necessary magic numbers)
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have made corresponding changes to the README and other relevant documentation
- [ ] My changes generate no new warnings

## Screenshots/Recordings (if appropriate)
[Add screenshots or recordings that demonstrate the changes]

## Additional Notes
[Add any additional information that might be helpful for reviewers]