### PR TITLE
fix: reboot of policy validation

### DIFF
--- a/internal/services/policy/resource_schema_reboot.go
+++ b/internal/services/policy/resource_schema_reboot.go
@@ -56,7 +56,7 @@ func getPolicySchemaReboot() *schema.Resource {
 				Default:     "Do not restart",
 				ValidateFunc: func(val any, key string) (warns []string, errs []error) {
 					v := val.(string)
-					validOptions := []string{"Restart if a package or update requires it", "Restart Immediately", "Do not restart"}
+					validOptions := []string{"Restart if a package or update requires it", "Restart immediately", "Do not restart"}
 					for _, option := range validOptions {
 						if v == option {
 							return
@@ -73,7 +73,7 @@ func getPolicySchemaReboot() *schema.Resource {
 				Description: "Action to take if a user is logged in to the computer",
 				ValidateFunc: func(val any, key string) (warns []string, errs []error) {
 					v := val.(string)
-					validOptions := []string{"Restart if a package or update requires it", "Restart Immediately", "Restart", "Do not restart"}
+					validOptions := []string{"Restart if a package or update requires it", "Restart immediately", "Restart", "Do not restart"}
 					for _, option := range validOptions {
 						if v == option {
 							return


### PR DESCRIPTION
# Pull Request Description

## Summary

This pull request updates the validation logic for the `no_user_logged_in` and `user_logged_in` field by correcting the capitalization of one option in the validOptions list.

### Issue Reference

n/a

### Motivation and Context

Specifically, the option "Restart Immediately" has been updated to "Restart immediately" to ensure consistent behavior and avoid unnecessary diffs during plan/apply operations.

### Dependencies
n/a

## Type of Change
Please mark the relevant option with an `x`:
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update (Wiki/README/Code comments)
- [ ] ♻️ Refactor (code improvement without functional changes)
- [ ] 🎨 Style update (formatting, renaming)
- [ ] 🔧 Configuration change
- [ ] 📦 Dependency update

## Testing
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added integration tests following the [testing implementation guide](../docs/testing-implementation.md)
- [ ] I have tested this code in the following browsers/environments: [list environments]

## Quality Checklist
- [x] I have reviewed my own code before requesting review
- [ ] I have verified there are no other open Pull Requests for the same update/change
- [ ] All CI/CD pipelines pass without errors or warnings
- [ ] My code follows the established style guidelines of this project
- [ ] My comments are used only when necessary, ideally where the codes purpose is not self explanatory (eg: necessary magic numbers)
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have made corresponding changes to the README and other relevant documentation
- [ ] My changes generate no new warnings

## Screenshots/Recordings (if appropriate)

<img width="1600" height="800" alt="" src="https://github.com/user-attachments/assets/2cadfba1-497c-4de3-945b-40568be900a6" />

## Additional Notes
[Add any additional information that might be helpful for reviewers]