### PR TITLE
feat: Optionally allow computer data sources to not be found

### DIFF
--- a/internal/services/computer_inventory/data_source_read.go
+++ b/internal/services/computer_inventory/data_source_read.go
@@ -187,13 +187,11 @@ func setGeneralSection(d *schema.ResourceData, general jamfpro.ComputerInventory
 	gen["declarative_device_management_enabled"] = general.DeclarativeDeviceManagementEnabled
 	gen["management_id"] = general.ManagementId
 
-	// Handle nested object 'remoteManagement'.
 	remoteManagement := make(map[string]any)
 	remoteManagement["managed"] = general.RemoteManagement.Managed
 	remoteManagement["management_username"] = general.RemoteManagement.ManagementUsername
 	gen["remote_management"] = []any{remoteManagement}
 
-	// Handle nested object 'site'.
 	if general.Site.ID != "" || general.Site.Name != "" {
 		site := make(map[string]any)
 		site["id"] = general.Site.ID
@@ -201,7 +199,6 @@ func setGeneralSection(d *schema.ResourceData, general jamfpro.ComputerInventory
 		gen["site_id"] = []any{site}
 	}
 
-	// Handle nested object 'enrollmentMethod'.
 	if general.EnrollmentMethod.ID != "" || general.EnrollmentMethod.ObjectName != "" || general.EnrollmentMethod.ObjectType != "" {
 		enrollmentMethod := make(map[string]any)
 		enrollmentMethod["id"] = general.EnrollmentMethod.ID
@@ -215,23 +212,19 @@ func setGeneralSection(d *schema.ResourceData, general jamfpro.ComputerInventory
 
 // setDiskEncryptionSection maps the 'diskEncryption' section of the computer inventory response to the Terraform resource data and updates the state.
 func setDiskEncryptionSection(d *schema.ResourceData, diskEncryption jamfpro.ComputerInventorySubsetDiskEncryption) error {
-	// Initialize a map to hold the 'diskEncryption' section attributes.
 	diskEnc := make(map[string]any)
 
-	// Map each attribute of the 'diskEncryption' section from the API response to the corresponding Terraform schema attribute.
 	diskEnc["individual_recovery_key_validity_status"] = diskEncryption.IndividualRecoveryKeyValidityStatus
 	diskEnc["institutional_recovery_key_present"] = diskEncryption.InstitutionalRecoveryKeyPresent
 	diskEnc["disk_encryption_configuration_name"] = diskEncryption.DiskEncryptionConfigurationName
 	diskEnc["file_vault2_eligibility_message"] = diskEncryption.FileVault2EligibilityMessage
 
-	// Handle nested object 'bootPartitionEncryptionDetails'.
 	bootPartitionDetails := make(map[string]any)
 	bootPartitionDetails["partition_name"] = diskEncryption.BootPartitionEncryptionDetails.PartitionName
 	bootPartitionDetails["partition_file_vault2_state"] = diskEncryption.BootPartitionEncryptionDetails.PartitionFileVault2State
 	bootPartitionDetails["partition_file_vault2_percent"] = diskEncryption.BootPartitionEncryptionDetails.PartitionFileVault2Percent
 	diskEnc["boot_partition_encryption_details"] = []any{bootPartitionDetails}
 
-	// Map 'fileVault2EnabledUserNames' as a list of strings.
 	fileVaultUserNames := make([]string, len(diskEncryption.FileVault2EnabledUserNames))
 	copy(fileVaultUserNames, diskEncryption.FileVault2EnabledUserNames)
 
@@ -242,10 +235,8 @@ func setDiskEncryptionSection(d *schema.ResourceData, diskEncryption jamfpro.Com
 
 // setPurchasingSection maps the 'purchasing' section of the computer inventory response to the Terraform resource data and updates the state.
 func setPurchasingSection(d *schema.ResourceData, purchasing jamfpro.ComputerInventorySubsetPurchasing) error {
-	// Initialize a map to hold the 'purchasing' section attributes.
 	purchasingMap := make(map[string]any)
 
-	// Map each attribute of the 'purchasing' section from the API response to the corresponding Terraform schema attribute.
 	purchasingMap["leased"] = purchasing.Leased
 	purchasingMap["purchased"] = purchasing.Purchased
 	purchasingMap["po_number"] = purchasing.PoNumber
@@ -259,7 +250,6 @@ func setPurchasingSection(d *schema.ResourceData, purchasing jamfpro.ComputerInv
 	purchasingMap["purchasing_account"] = purchasing.PurchasingAccount
 	purchasingMap["purchasing_contact"] = purchasing.PurchasingContact
 
-	// Map 'extensionAttributes' as a list of maps.
 	extAttrs := make([]map[string]any, len(purchasing.ExtensionAttributes))
 	for i, attr := range purchasing.ExtensionAttributes {
 		attrMap := make(map[string]any)
@@ -282,14 +272,10 @@ func setPurchasingSection(d *schema.ResourceData, purchasing jamfpro.ComputerInv
 
 // setApplicationsSection maps the 'applications' section of the computer inventory response to the Terraform resource data and updates the state.
 func setApplicationsSection(d *schema.ResourceData, applications []jamfpro.ComputerInventorySubsetApplication) error {
-	// Create a slice to hold the application maps.
 	apps := make([]any, len(applications))
 
 	for i, app := range applications {
-		// Initialize a map for each application.
 		appMap := make(map[string]any)
-
-		// Map each attribute of the application from the API response to the corresponding Terraform schema attribute.
 		appMap["name"] = app.Name
 		appMap["path"] = app.Path
 		appMap["version"] = app.Version
@@ -299,7 +285,6 @@ func setApplicationsSection(d *schema.ResourceData, applications []jamfpro.Compu
 		appMap["update_available"] = app.UpdateAvailable
 		appMap["external_version_id"] = app.ExternalVersionId
 
-		// Add the application map to the slice.
 		apps[i] = appMap
 	}
 
@@ -312,7 +297,6 @@ func setStorageSection(d *schema.ResourceData, storage jamfpro.ComputerInventory
 
 	storageMap["boot_drive_available_space_megabytes"] = storage.BootDriveAvailableSpaceMegabytes
 
-	// Mapping 'disks' array
 	disks := make([]any, len(storage.Disks))
 	for i, disk := range storage.Disks {
 		diskMap := make(map[string]any)
@@ -325,7 +309,6 @@ func setStorageSection(d *schema.ResourceData, storage jamfpro.ComputerInventory
 		diskMap["smart_status"] = disk.SmartStatus
 		diskMap["type"] = disk.Type
 
-		// Map 'partitions' if present
 		partitions := make([]any, len(disk.Partitions))
 		for j, partition := range disk.Partitions {
 			partitionMap := make(map[string]any)
@@ -352,7 +335,6 @@ func setStorageSection(d *schema.ResourceData, storage jamfpro.ComputerInventory
 func setUserAndLocationSection(d *schema.ResourceData, userAndLocation jamfpro.ComputerInventorySubsetUserAndLocation) error {
 	userLocationMap := make(map[string]any)
 
-	// Map each attribute from the 'userAndLocation' object to the corresponding schema attribute
 	userLocationMap["username"] = userAndLocation.Username
 	userLocationMap["realname"] = userAndLocation.Realname
 	userLocationMap["email"] = userAndLocation.Email
@@ -362,7 +344,6 @@ func setUserAndLocationSection(d *schema.ResourceData, userAndLocation jamfpro.C
 	userLocationMap["building_id"] = userAndLocation.BuildingId
 	userLocationMap["room"] = userAndLocation.Room
 
-	// Map extension attributes if present
 	if len(userAndLocation.ExtensionAttributes) > 0 {
 		extAttrs := make([]map[string]any, len(userAndLocation.ExtensionAttributes))
 		for i, attr := range userAndLocation.ExtensionAttributes {
@@ -389,7 +370,6 @@ func setUserAndLocationSection(d *schema.ResourceData, userAndLocation jamfpro.C
 func setHardwareSection(d *schema.ResourceData, hardware jamfpro.ComputerInventorySubsetHardware) error {
 	hardwareMap := make(map[string]any)
 
-	// Map each attribute from the 'hardware' object to the corresponding schema attribute
 	hardwareMap["make"] = hardware.Make
 	hardwareMap["model"] = hardware.Model
 	hardwareMap["model_identifier"] = hardware.ModelIdentifier
@@ -416,7 +396,6 @@ func setHardwareSection(d *schema.ResourceData, hardware jamfpro.ComputerInvento
 	hardwareMap["supports_ios_app_installs"] = hardware.SupportsIosAppInstalls
 	hardwareMap["apple_silicon"] = hardware.AppleSilicon
 
-	// Map extension attributes if present
 	if len(hardware.ExtensionAttributes) > 0 {
 		extAttrs := make([]map[string]any, len(hardware.ExtensionAttributes))
 		for i, attr := range hardware.ExtensionAttributes {
@@ -563,7 +542,7 @@ func setOperatingSystemSection(d *schema.ResourceData, operatingSystem jamfpro.C
 	osMap["active_directory_status"] = operatingSystem.ActiveDirectoryStatus
 	osMap["filevault2_status"] = operatingSystem.FileVault2Status
 	osMap["software_update_device_id"] = operatingSystem.SoftwareUpdateDeviceId
-	// Map extension attributes if present
+
 	extAttrs := make([]map[string]any, len(operatingSystem.ExtensionAttributes))
 	for i, attr := range operatingSystem.ExtensionAttributes {
 		attrMap := make(map[string]any)

--- a/internal/services/computer_inventory/data_source_read.go
+++ b/internal/services/computer_inventory/data_source_read.go
@@ -54,7 +54,6 @@ func dataSourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.
 		return diag.FromErr(fmt.Errorf("failed to fetch computer inventory: %v", err))
 	}
 
-	// Set top-level attributes
 	d.SetId(computer.ID)
 	d.Set("id", computer.ID)
 	d.Set("udid", computer.UDID)
@@ -63,112 +62,90 @@ func dataSourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.
 		return diag.FromErr(err)
 	}
 
-	// Set 'diskEncryption' section
 	if err := setDiskEncryptionSection(d, computer.DiskEncryption); err != nil {
 		return diag.FromErr(err)
 	}
 
-	// Set 'purchasing' section
 	if err := setPurchasingSection(d, computer.Purchasing); err != nil {
 		return diag.FromErr(err)
 	}
 
-	// Set 'applications' section
 	if err := setApplicationsSection(d, computer.Applications); err != nil {
 		return diag.FromErr(err)
 	}
 
-	// Set 'storage' section
 	if err := setStorageSection(d, computer.Storage); err != nil {
 		return diag.FromErr(err)
 	}
 
-	// Set 'userAndLocation' section
 	if err := setUserAndLocationSection(d, computer.UserAndLocation); err != nil {
 		return diag.FromErr(err)
 	}
 
-	// Set 'hardware' section
 	if err := setHardwareSection(d, computer.Hardware); err != nil {
 		return diag.FromErr(err)
 	}
 
-	// Set 'localUserAccounts' section
 	if err := setLocalUserAccountsSection(d, computer.LocalUserAccounts); err != nil {
 		return diag.FromErr(err)
 	}
 
-	// Set 'certificates' section
 	if err := setCertificatesSection(d, computer.Certificates); err != nil {
 		return diag.FromErr(err)
 	}
 
-	// Set 'attachments' section
 	if err := setAttachmentsSection(d, computer.Attachments); err != nil {
 		return diag.FromErr(err)
 	}
 
-	// Set 'plugins' section
 	if err := setPluginsSection(d, computer.Plugins); err != nil {
 		return diag.FromErr(err)
 	}
 
-	// Set 'packageReceipts' section
 	if err := setPackageReceiptsSection(d, computer.PackageReceipts); err != nil {
 		return diag.FromErr(err)
 	}
 
-	// Set 'fonts' section
 	if err := setFontsSection(d, computer.Fonts); err != nil {
 		return diag.FromErr(err)
 	}
 
-	// Set 'security' section
 	if err := setSecuritySection(d, computer.Security); err != nil {
 		return diag.FromErr(err)
 	}
 
-	// Set 'operatingSystem' section
 	if err := setOperatingSystemSection(d, computer.OperatingSystem); err != nil {
 		return diag.FromErr(err)
 	}
 
-	// Set 'licensedSoftware' section
 	if err := setLicensedSoftwareSection(d, computer.LicensedSoftware); err != nil {
 		return diag.FromErr(err)
 	}
 
-	// Set 'ibeacons' section
 	if err := setIBeaconsSection(d, computer.Ibeacons); err != nil {
 		return diag.FromErr(err)
 	}
 
-	// Set 'softwareUpdates' section
 	if err := setSoftwareUpdatesSection(d, computer.SoftwareUpdates); err != nil {
 		return diag.FromErr(err)
 	}
 
-	// Set 'extensionAttributes' section
 	if err := setExtensionAttributesSection(d, computer.ExtensionAttributes); err != nil {
 		return diag.FromErr(err)
 	}
 
-	// Set 'groupMemberships' section
 	if err := setGroupMembershipsSection(d, computer.GroupMemberships); err != nil {
 		return diag.FromErr(err)
 	}
 
-	// Set 'configurationProfiles' section
 	if err := setConfigurationProfilesSection(d, computer.ConfigurationProfiles); err != nil {
 		return diag.FromErr(err)
 	}
 
-	// Set 'printers' section
 	if err := setPrintersSection(d, computer.Printers); err != nil {
 		return diag.FromErr(err)
 	}
 
-	// Set 'services' section
 	if err := setServicesSection(d, computer.Services); err != nil {
 		return diag.FromErr(err)
 	}
@@ -233,7 +210,6 @@ func setGeneralSection(d *schema.ResourceData, general jamfpro.ComputerInventory
 		gen["enrollment_method"] = []any{enrollmentMethod}
 	}
 
-	// Set the 'general' section in the Terraform resource data.
 	return d.Set("general", []any{gen})
 }
 
@@ -259,10 +235,8 @@ func setDiskEncryptionSection(d *schema.ResourceData, diskEncryption jamfpro.Com
 	fileVaultUserNames := make([]string, len(diskEncryption.FileVault2EnabledUserNames))
 	copy(fileVaultUserNames, diskEncryption.FileVault2EnabledUserNames)
 
-	// Set 'fileVault2EnabledUserNames' in the 'diskEnc' map.
 	diskEnc["file_vault2_enabled_user_names"] = fileVaultUserNames
 
-	// Set the 'diskEncryption' section in the Terraform resource data.
 	return d.Set("disk_encryption", []any{diskEnc})
 }
 
@@ -303,7 +277,6 @@ func setPurchasingSection(d *schema.ResourceData, purchasing jamfpro.ComputerInv
 	}
 	purchasingMap["extension_attributes"] = extAttrs
 
-	// Set the 'purchasing' section in the Terraform resource data.
 	return d.Set("purchasing", []any{purchasingMap})
 }
 
@@ -330,7 +303,6 @@ func setApplicationsSection(d *schema.ResourceData, applications []jamfpro.Compu
 		apps[i] = appMap
 	}
 
-	// Set the 'applications' section in the Terraform resource data.
 	return d.Set("applications", apps)
 }
 
@@ -373,7 +345,6 @@ func setStorageSection(d *schema.ResourceData, storage jamfpro.ComputerInventory
 	}
 	storageMap["disks"] = disks
 
-	// Set the 'storage' section in the Terraform resource data.
 	return d.Set("storage", []any{storageMap})
 }
 
@@ -411,7 +382,6 @@ func setUserAndLocationSection(d *schema.ResourceData, userAndLocation jamfpro.C
 		userLocationMap["extension_attributes"] = extAttrs
 	}
 
-	// Set the 'userAndLocation' section in the Terraform resource data
 	return d.Set("user_and_location", []any{userLocationMap})
 }
 
@@ -466,7 +436,6 @@ func setHardwareSection(d *schema.ResourceData, hardware jamfpro.ComputerInvento
 		hardwareMap["extension_attributes"] = extAttrs
 	}
 
-	// Set the 'hardware' section in the Terraform resource data
 	return d.Set("hardware", []any{hardwareMap})
 }
 

--- a/internal/services/computer_inventory/data_source_read.go
+++ b/internal/services/computer_inventory/data_source_read.go
@@ -25,7 +25,7 @@ func dataSourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	var computer *jamfpro.ResourceComputerInventory
 	var err error
 
-	allow_not_found := d.Get("allow_not_found").(bool)
+	warn_if_not_found := d.Get("warn_if_not_found").(bool)
 
 	if val, ok := d.GetOk("name"); ok {
 		ident = val.(string)
@@ -44,11 +44,11 @@ func dataSourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	}
 
 	if err != nil {
-		if allow_not_found {
+		if warn_if_not_found {
 			return append(diags, diag.Diagnostic{
 				Severity: diag.Warning,
 				Summary:  fmt.Sprintf("Computer at %s not found", ident),
-				Detail:   fmt.Sprintf("Not erroring due to allow_not_found enabled\nerr: %v", err),
+				Detail:   fmt.Sprintf("Not erroring due to warn_if_not_found enabled\nerr: %v", err),
 			})
 		}
 

--- a/internal/services/computer_inventory/data_source_read.go
+++ b/internal/services/computer_inventory/data_source_read.go
@@ -56,8 +56,16 @@ func dataSourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	}
 
 	d.SetId(computer.ID)
-	d.Set("id", computer.ID)
-	d.Set("udid", computer.UDID)
+
+	err = d.Set("id", computer.ID)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	err = d.Set("udid", computer.UDID)
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
 	if err := setGeneralSection(d, computer.General); err != nil {
 		return diag.FromErr(err)

--- a/internal/services/computer_inventory/data_source_schema.go
+++ b/internal/services/computer_inventory/data_source_schema.go
@@ -14,6 +14,11 @@ func DataSourceJamfProComputerInventory() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+			"allow_not_found": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 			"name": {
 				Type:     schema.TypeString,
 				Optional: true,

--- a/internal/services/computer_inventory/data_source_schema.go
+++ b/internal/services/computer_inventory/data_source_schema.go
@@ -14,10 +14,11 @@ func DataSourceJamfProComputerInventory() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
-			"allow_not_found": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
+			"warn_if_not_found": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "Enabling this setting will cause the provider to only WARN if a computer is not found",
 			},
 			"name": {
 				Type:     schema.TypeString,

--- a/internal/services/computer_inventory/data_source_schema.go
+++ b/internal/services/computer_inventory/data_source_schema.go
@@ -18,7 +18,7 @@ func DataSourceJamfProComputerInventory() *schema.Resource {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     false,
-				Description: "Enabling this setting will cause the provider to only WARN if a computer is not found",
+				Description: "Enabling this setting will cause the provider to only WARN if a computer is not found. By default the provider will ERROR.",
 			},
 			"name": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
```
data "jamfpro_computer_inventory" "by_serial" {
  for_each = toset(["VALID_SERIAL", "INVALID_SERIAL"])
  warn_if_not_found = true
  serial_number   = each.key
}

locals {
  test = {
    for serial, inv in data.jamfpro_computer_inventory.example_by_serial_working :
    serial => inv.id
  }
}


output "working" {
  value = local.test
}
```

One of those serials is valid, the other is not. With warn_if_not_found set to true, the output will now be: 

```
Changes to Outputs:
  + working = {
      + VALID_SERIAL = "21"
      + INVALID_SERIAL  = null
    }

You can apply this plan to save these new output values to the Terraform state, without changing any real infrastructure.
╷
│ Warning: Computer at INVALID_SERIAL not found
│ 
│   with data.jamfpro_computer_inventory.by_serial["INVALID_SERIAL"],
│   on infra.tf line 7, in data "jamfpro_computer_inventory" "by_serial":
│    7: data "jamfpro_computer_inventory" "by_serial" {
│ 
│ Not erroring due to warn_if_not_found enabled
│ err: failed to find computer inventory by serial number 'INVALID_SERIAL'
```

warn_if_not_found is FALSE by default. This change will not affect existing implementations.


