### PR TITLE
fix: Add new valid version to Computer Prestage validation

### DIFF
--- a/internal/services/computer_prestage_enrollment/resource_custom_diff.go
+++ b/internal/services/computer_prestage_enrollment/resource_custom_diff.go
@@ -18,9 +18,9 @@ func mainCustomDiffFunc(ctx context.Context, diff *schema.ResourceDiff, i any) e
 		return err
 	}
 
-	if err := validateMinimumOSSpecificVersion(ctx, diff, i); err != nil {
-		return err
-	}
+	// if err := validateMinimumOSSpecificVersion(ctx, diff, i); err != nil {
+	// 	return err
+	// }
 
 	return nil
 }

--- a/internal/services/computer_prestage_enrollment/resource_custom_diff.go
+++ b/internal/services/computer_prestage_enrollment/resource_custom_diff.go
@@ -18,9 +18,9 @@ func mainCustomDiffFunc(ctx context.Context, diff *schema.ResourceDiff, i any) e
 		return err
 	}
 
-	// if err := validateMinimumOSSpecificVersion(ctx, diff, i); err != nil {
-	// 	return err
-	// }
+	if err := validateMinimumOSSpecificVersion(ctx, diff, i); err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -130,6 +130,7 @@ func validateMinimumOSSpecificVersion(_ context.Context, diff *schema.ResourceDi
 			"14.5":   true,
 			"14.6":   true,
 			"14.6.1": true,
+			"26.3.1": true,
 		}
 
 		if !validVersions[specificVersion] {


### PR DESCRIPTION
Versions are outdated, commenting out because this will likely rear it's head again.