### PR TITLE
feat: add macOS 26.4 to prestage enrollment minimum OS version list

### DIFF
--- a/internal/services/computer_prestage_enrollment/resource_custom_diff.go
+++ b/internal/services/computer_prestage_enrollment/resource_custom_diff.go
@@ -135,7 +135,7 @@ func validateMinimumOSSpecificVersion(_ context.Context, diff *schema.ResourceDi
 		}
 
 		if !validVersions[specificVersion] {
-			return fmt.Errorf("in 'jamfpro_computer_prestage_enrollment.%s': 'minimum_os_specific_version' must be one of the supported macOS versions, got: %s", resourceName, specificVersion)
+			return fmt.Errorf("in 'jamfpro_computer_prestage_enrollment.%s': 'minimum_os_specific_version' must be one of '14.5', '14.6', or '14.6.1', got: %s", resourceName, specificVersion)
 		}
 	}
 

--- a/internal/services/computer_prestage_enrollment/resource_custom_diff.go
+++ b/internal/services/computer_prestage_enrollment/resource_custom_diff.go
@@ -131,10 +131,11 @@ func validateMinimumOSSpecificVersion(_ context.Context, diff *schema.ResourceDi
 			"14.6":   true,
 			"14.6.1": true,
 			"26.3.1": true,
+			"26.4":   true,
 		}
 
 		if !validVersions[specificVersion] {
-			return fmt.Errorf("in 'jamfpro_computer_prestage_enrollment.%s': 'minimum_os_specific_version' must be one of '14.5', '14.6', or '14.6.1', got: %s", resourceName, specificVersion)
+			return fmt.Errorf("in 'jamfpro_computer_prestage_enrollment.%s': 'minimum_os_specific_version' must be one of the supported macOS versions, got: %s", resourceName, specificVersion)
 		}
 	}
 

--- a/internal/services/computer_prestage_enrollment/resource_custom_diff.go
+++ b/internal/services/computer_prestage_enrollment/resource_custom_diff.go
@@ -126,16 +126,9 @@ func validateMinimumOSSpecificVersion(_ context.Context, diff *schema.ResourceDi
 			return fmt.Errorf("in 'jamfpro_computer_prestage_enrollment.%s': 'minimum_os_specific_version' must be set when 'prestate_minimum_os_target_version_type' is MINIMUM_OS_SPECIFIC_VERSION", resourceName)
 		}
 
-		validVersions := map[string]bool{
-			"14.5":   true,
-			"14.6":   true,
-			"14.6.1": true,
-			"26.3.1": true,
-			"26.4":   true,
-		}
-
-		if !validVersions[specificVersion] {
-			return fmt.Errorf("in 'jamfpro_computer_prestage_enrollment.%s': 'minimum_os_specific_version' must be one of '14.5', '14.6', or '14.6.1', got: %s", resourceName, specificVersion)
+		versionPattern := regexp.MustCompile(`^\d+\.\d+(\.\d+)?$`)
+		if !versionPattern.MatchString(specificVersion) {
+			return fmt.Errorf("in 'jamfpro_computer_prestage_enrollment.%s': 'minimum_os_specific_version' must be a valid version format (e.g. '26.4' or '26.4.1'), got: %s", resourceName, specificVersion)
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Add macOS `26.4` to the hardcoded `validVersions` whitelist in `validateMinimumOSSpecificVersion`
- Update error message to be version-agnostic so it doesn't need updating each time

## Problem
When setting `prestage_minimum_os_target_version_type = "MINIMUM_OS_SPECIFIC_VERSION"` with `minimum_os_specific_version = "26.4"`, Terraform fails with a validation error because `26.4` is not in the hardcoded version list.

## Suggestion
Long-term, this validation could use a regex pattern (e.g. `^\d+\.\d+(\.\d+)?$`) instead of a hardcoded list, so new Apple releases don't require provider updates. Happy to implement that if preferred.