### PR TITLE
fix: change onboarding_items from TypeList to TypeSet to eliminate spurious diffs

### DIFF
--- a/internal/services/macos_onboarding_settings/resource_constructor.go
+++ b/internal/services/macos_onboarding_settings/resource_constructor.go
@@ -15,7 +15,7 @@ func construct(d *schema.ResourceData) (*jamfpro.ResourceUpdateOnboardingSetting
 	var onboardingItems []jamfpro.SubsetOnboardingItemRequest
 
 	if v, ok := d.GetOk("onboarding_items"); ok {
-		itemsList := v.([]any)
+		itemsList := v.(*schema.Set).List()
 		onboardingItems = make([]jamfpro.SubsetOnboardingItemRequest, 0, len(itemsList))
 
 		for _, item := range itemsList {

--- a/internal/services/macos_onboarding_settings/resource_schema.go
+++ b/internal/services/macos_onboarding_settings/resource_schema.go
@@ -28,7 +28,7 @@ func ResourceJamfProMacOSOnboardingSettings() *schema.Resource {
 				Description: "Enable or disable macOS onboarding",
 			},
 			"onboarding_items": {
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Optional:    true,
 				Description: "List of onboarding items to display during device setup",
 				Elem: &schema.Resource{

--- a/internal/services/macos_onboarding_settings/resource_schema.go
+++ b/internal/services/macos_onboarding_settings/resource_schema.go
@@ -15,6 +15,14 @@ func ResourceJamfProMacOSOnboardingSettings() *schema.Resource {
 		ReadContext:   readWithCleanup,
 		UpdateContext: update,
 		DeleteContext: delete,
+		SchemaVersion: 1,
+		StateUpgraders: []schema.StateUpgrader{
+			{
+				Type:    resourceMacOSOnboardingSettingsV0().CoreConfigSchema().ImpliedType(),
+				Upgrade: upgradeMacOSOnboardingSettingsV0toV1,
+				Version: 0,
+			},
+		},
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(1 * time.Minute),
 			Read:   schema.DefaultTimeout(1 * time.Minute),

--- a/internal/services/macos_onboarding_settings/resource_state_migration.go
+++ b/internal/services/macos_onboarding_settings/resource_state_migration.go
@@ -1,0 +1,65 @@
+package macos_onboarding_settings
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+// resourceMacOSOnboardingSettingsV0 returns the V0 schema where onboarding_items was a TypeList.
+func resourceMacOSOnboardingSettingsV0() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"enabled": {
+				Type:     schema.TypeBool,
+				Required: true,
+			},
+			"onboarding_items": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"entity_id": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"entity_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"scope_description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"site_description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"self_service_entity_type": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice([]string{"OS_X_POLICY", "OS_X_MAC_APP", "OS_X_CONFIGURATION_PROFILE"}, false),
+						},
+						"priority": {
+							Type:         schema.TypeInt,
+							Required:     true,
+							ValidateFunc: validation.IntAtLeast(1),
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// upgradeMacOSOnboardingSettingsV0toV1 migrates state from V0 (TypeList) to V1 (TypeSet).
+// The underlying data structure is identical; re-encoding is sufficient for Terraform to
+// re-hash the items using the new TypeSet schema.
+func upgradeMacOSOnboardingSettingsV0toV1(_ context.Context, rawState map[string]any, _ any) (map[string]any, error) {
+	return rawState, nil
+}

--- a/internal/services/macos_onboarding_settings/resource_state_migration_test.go
+++ b/internal/services/macos_onboarding_settings/resource_state_migration_test.go
@@ -1,0 +1,165 @@
+package macos_onboarding_settings
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestUpgradeMacOSOnboardingSettingsV0toV1 verifies that state produced by the
+// V0 schema (where onboarding_items was a TypeList) can be re-loaded by the
+// V1 schema (TypeSet) without losing data or producing spurious diffs.
+//
+// TypeList and TypeSet share the same wire format in raw state ([]any of
+// map[string]any), so the upgrade itself is a pass-through. These tests pin
+// that invariant down so a future change to either schema can't silently
+// break existing state.
+func TestUpgradeMacOSOnboardingSettingsV0toV1(t *testing.T) {
+	tests := []struct {
+		name     string
+		rawState map[string]any
+	}{
+		{
+			name: "single item",
+			rawState: map[string]any{
+				"enabled": true,
+				"onboarding_items": []any{
+					map[string]any{
+						"id":                       "14",
+						"entity_id":                "76",
+						"entity_name":              "Recon Policy",
+						"scope_description":        "All Computers",
+						"site_description":         "None",
+						"self_service_entity_type": "OS_X_POLICY",
+						"priority":                 1,
+					},
+				},
+			},
+		},
+		{
+			name: "multiple items out of priority order",
+			rawState: map[string]any{
+				"enabled": true,
+				"onboarding_items": []any{
+					map[string]any{
+						"id":                       "16",
+						"entity_id":                "136",
+						"entity_name":              "Item C",
+						"scope_description":        "All Computers",
+						"site_description":         "None",
+						"self_service_entity_type": "OS_X_POLICY",
+						"priority":                 3,
+					},
+					map[string]any{
+						"id":                       "14",
+						"entity_id":                "76",
+						"entity_name":              "Item A",
+						"scope_description":        "All Computers",
+						"site_description":         "None",
+						"self_service_entity_type": "OS_X_POLICY",
+						"priority":                 1,
+					},
+					map[string]any{
+						"id":                       "15",
+						"entity_id":                "134",
+						"entity_name":              "Item B",
+						"scope_description":        "All Computers",
+						"site_description":         "None",
+						"self_service_entity_type": "OS_X_MAC_APP",
+						"priority":                 2,
+					},
+				},
+			},
+		},
+		{
+			name: "empty onboarding_items",
+			rawState: map[string]any{
+				"enabled":          false,
+				"onboarding_items": []any{},
+			},
+		},
+		{
+			name: "onboarding_items absent",
+			rawState: map[string]any{
+				"enabled": true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Sanity check: the rawState must be valid under the V0 schema we
+			// are migrating from, otherwise the test premise is wrong.
+			_ = schema.TestResourceDataRaw(
+				t,
+				resourceMacOSOnboardingSettingsV0().Schema,
+				tt.rawState,
+			)
+
+			upgraded, err := upgradeMacOSOnboardingSettingsV0toV1(
+				context.Background(),
+				tt.rawState,
+				nil,
+			)
+			require.NoError(t, err)
+			require.NotNil(t, upgraded)
+
+			// Pass-through migration: structure must be preserved verbatim so
+			// the SDK can re-hash list entries into the new TypeSet without
+			// losing data.
+			assert.Equal(t, tt.rawState, upgraded)
+
+			// The upgraded state must round-trip cleanly through the V1
+			// (current) schema.
+			rd := schema.TestResourceDataRaw(
+				t,
+				ResourceJamfProMacOSOnboardingSettings().Schema,
+				upgraded,
+			)
+			assert.Equal(t, tt.rawState["enabled"], rd.Get("enabled"))
+
+			gotItems := rd.Get("onboarding_items").(*schema.Set).List()
+			wantItems, _ := tt.rawState["onboarding_items"].([]any)
+			assert.Len(t, gotItems, len(wantItems))
+
+			// Every input item must appear in the resulting set with all
+			// fields intact (Set is order-independent, so compare as a
+			// multiset keyed by id).
+			byID := make(map[string]map[string]any, len(gotItems))
+			for _, it := range gotItems {
+				m := it.(map[string]any)
+				byID[m["id"].(string)] = m
+			}
+			for _, raw := range wantItems {
+				want := raw.(map[string]any)
+				got, ok := byID[want["id"].(string)]
+				if !assert.True(t, ok, "missing item id=%v in upgraded state", want["id"]) {
+					continue
+				}
+				assert.Equal(t, want["entity_id"], got["entity_id"])
+				assert.Equal(t, want["entity_name"], got["entity_name"])
+				assert.Equal(t, want["scope_description"], got["scope_description"])
+				assert.Equal(t, want["site_description"], got["site_description"])
+				assert.Equal(t, want["self_service_entity_type"], got["self_service_entity_type"])
+				assert.Equal(t, want["priority"], got["priority"])
+			}
+		})
+	}
+}
+
+// TestStateUpgraderWiring verifies the resource's StateUpgraders slice is
+// wired correctly so the V0->V1 path is actually exercised by Terraform.
+func TestStateUpgraderWiring(t *testing.T) {
+	r := ResourceJamfProMacOSOnboardingSettings()
+
+	assert.Equal(t, 1, r.SchemaVersion, "current schema version must be 1")
+	require.Len(t, r.StateUpgraders, 1)
+
+	u := r.StateUpgraders[0]
+	assert.Equal(t, 0, u.Version, "upgrader source version must be 0")
+	assert.NotNil(t, u.Upgrade, "upgrader must have an Upgrade function")
+	assert.NotNil(t, u.Type, "upgrader must declare the prior schema type")
+}

--- a/testing/payloads/jamfpro_macos_onboarding_settings/main.tf
+++ b/testing/payloads/jamfpro_macos_onboarding_settings/main.tf
@@ -1,20 +1,44 @@
 resource "jamfpro_policy" "recon" {
-  name      = "Do A Recon for Onboarding and Profit"
-  enabled   = true
-  frequency = "Ongoing"
+  name                          = "acc-test-policy-onboarding-recon"
+  enabled                       = true
+  trigger_checkin               = false
+  trigger_enrollment_complete   = false
+  trigger_login                 = false
+  trigger_network_state_changed = false
+  trigger_startup               = false
+  trigger_other                 = "USER_INITIATED"
+  frequency                     = "Ongoing"
+  retry_event                   = "none"
+  retry_attempts                = -1
+  notify_on_each_failed_retry   = false
+  target_drive                  = "/"
+  offline                       = false
+  category_id                   = -1
+  site_id                       = -1
+
+  network_limitations {
+    minimum_network_connection = "No Minimum"
+    any_ip_address             = false
+  }
 
   scope {
     all_computers = true
     all_jss_users = false
-
   }
+
   self_service {
     use_for_self_service            = true
     self_service_display_name       = "Do the thing"
     install_button_text             = "Install"
     reinstall_button_text           = "Reinstall"
+    self_service_description        = ""
     force_users_to_view_description = false
     feature_on_main_page            = false
+
+    notification         = false
+    notification_type    = "Self Service"
+    notification_subject = "Recon"
+    notification_message = "This is a message for the Recon policy"
   }
 
   payloads {


### PR DESCRIPTION
# Pull Request Description

## Summary

- Changed `onboarding_items` schema attribute from `schema.TypeList` to `schema.TypeSet`
- Added a `SchemaVersion: 1` state upgrader for existing `jamfpro_macos_onboarding_settings` state
- Updated constructor to read the set via `v.(*schema.Set).List()` instead of `v.([]any)`
- No manual `terraform state rm` / `terraform import` migration is required for existing state

### Issue Reference

n/a

### Motivation and Context

`TypeList` is order-sensitive, causing Terraform to detect spurious diffs whenever the Jamf Pro API returns `onboarding_items` in a different order than the configuration. `TypeSet` is order-independent, so only actual item changes should trigger a diff.

Because this changes the Terraform schema type for an existing attribute, this PR also adds a state upgrader from schema version 0 to schema version 1. The raw Terraform state representation for the old list and the new set is compatible for this nested block shape, so the upgrader preserves the existing state and lets Terraform re-read it with the current `TypeSet` schema.

### Dependencies

n/a

## Type of Change
Please mark the relevant option with an `x`:
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update (Wiki/README/Code comments)
- [ ] ♻️ Refactor (code improvement without functional changes)
- [ ] 🎨 Style update (formatting, renaming)
- [ ] 🔧 Configuration change
- [ ] 📦 Dependency update

## Testing
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing targeted unit tests pass locally with my changes
- [x] I have tested this against a real Jamf Pro tenant
- [ ] I have tested this code in the following browsers/environments: [list environments]

### Unit Test

```console
$ GOCACHE="$PWD/.tmp/go-build-cache" GOMODCACHE="$PWD/.tmp/go-mod-cache" go test ./internal/services/macos_onboarding_settings
ok  	github.com/deploymenttheory/terraform-provider-jamfpro/internal/services/macos_onboarding_settings	0.472s
```

### Real Tenant Migration Verification

Verified against `https://onishidev.jamfcloud.com` on June 12, 2026 (JST), using:

- Terraform `v1.14.6`
- Old provider binary built from tag `v0.37.0`
- PR provider binary built from this branch (`patch-macos-onbording`)
- Three temporary Self Service policies created by Terraform:
  - `tf-pr1077-onboarding-alpha-pr1077-migration-20260612171326` / ID `11`
  - `tf-pr1077-onboarding-bravo-pr1077-migration-20260612171326` / ID `9`
  - `tf-pr1077-onboarding-charlie-pr1077-migration-20260612171326` / ID `10`
- `jamfpro_macos_onboarding_settings` singleton ID: `jamfpro_macos_onboarding_settings_singleton`

This verification uses three `onboarding_items`, not a single item. The HCL intentionally declares the onboarding blocks in `charlie -> alpha -> bravo` order with priorities `3 -> 1 -> 2`, so the test covers the original list-order problem rather than only proving the single-item case.

#### HCL used for the migration test

```hcl
resource "jamfpro_policy" "recon" {
  for_each = {
    alpha   = 1
    bravo   = 2
    charlie = 3
  }

  name                          = "tf-pr1077-onboarding-${each.key}-pr1077-migration-20260612171326"
  enabled                       = true
  trigger_checkin               = false
  trigger_enrollment_complete   = false
  trigger_login                 = false
  trigger_network_state_changed = false
  trigger_startup               = false
  trigger_other                 = "USER_INITIATED"
  frequency                     = "Ongoing"
  retry_event                   = "none"
  retry_attempts                = -1
  notify_on_each_failed_retry   = false
  target_drive                  = "/"
  offline                       = false
  category_id                   = -1
  site_id                       = -1

  network_limitations {
    minimum_network_connection = "No Minimum"
    any_ip_address             = false
  }

  scope {
    all_computers = true
    all_jss_users = false
  }

  self_service {
    use_for_self_service            = true
    self_service_display_name       = "Terraform PR1077 migration test ${each.key}"
    install_button_text             = "Install"
    reinstall_button_text           = "Reinstall"
    self_service_description        = "Temporary policy used to verify Terraform provider state migration for ${each.key}."
    force_users_to_view_description = false
    feature_on_main_page            = false
    notification                    = false
  }

  payloads {
    maintenance {
      recon = true
    }
  }
}

resource "jamfpro_macos_onboarding_settings" "migration_test" {
  enabled = true

  onboarding_items {
    entity_id                = jamfpro_policy.recon["charlie"].id
    self_service_entity_type = "OS_X_POLICY"
    priority                 = 3
  }

  onboarding_items {
    entity_id                = jamfpro_policy.recon["alpha"].id
    self_service_entity_type = "OS_X_POLICY"
    priority                 = 1
  }

  onboarding_items {
    entity_id                = jamfpro_policy.recon["bravo"].id
    self_service_entity_type = "OS_X_POLICY"
    priority                 = 2
  }
}
```

#### Step 1: create existing multi-item state with `v0.37.0`

```console
$ TF_CLI_CONFIG_FILE=terraformrc-v037.tfrc terraform apply -auto-approve -input=false -no-color
jamfpro_policy.recon["bravo"]: Creation complete after 1s [id=9]
jamfpro_policy.recon["charlie"]: Creation complete after 1s [id=10]
jamfpro_policy.recon["alpha"]: Creation complete after 1s [id=11]
jamfpro_macos_onboarding_settings.migration_test: Creation complete after 1s [id=jamfpro_macos_onboarding_settings_singleton]

Apply complete! Resources: 4 added, 0 changed, 0 destroyed.
```

The resulting existing state had `schema_version: 0` and contained all three onboarding items:

```json
{
  "type": "jamfpro_macos_onboarding_settings",
  "name": "migration_test",
  "instances": [
    {
      "schema_version": 0,
      "attributes": {
        "id": "jamfpro_macos_onboarding_settings_singleton",
        "enabled": true,
        "onboarding_items": [
          {
            "entity_id": "10",
            "entity_name": "tf-pr1077-onboarding-charlie-pr1077-migration-20260612171326",
            "id": "5",
            "priority": 3,
            "scope_description": "All computers",
            "self_service_entity_type": "OS_X_POLICY",
            "site_description": "None"
          },
          {
            "entity_id": "11",
            "entity_name": "tf-pr1077-onboarding-alpha-pr1077-migration-20260612171326",
            "id": "6",
            "priority": 1,
            "scope_description": "All computers",
            "self_service_entity_type": "OS_X_POLICY",
            "site_description": "None"
          },
          {
            "entity_id": "9",
            "entity_name": "tf-pr1077-onboarding-bravo-pr1077-migration-20260612171326",
            "id": "7",
            "priority": 2,
            "scope_description": "All computers",
            "self_service_entity_type": "OS_X_POLICY",
            "site_description": "None"
          }
        ]
      }
    }
  ]
}
```

#### Step 2: reproduce the original repeated diff with `v0.37.0`

After the initial `v0.37.0` apply, I ran `plan` again without changing HCL. This reproduced the original issue: the old `TypeList` schema produced an in-place update for the same three onboarding items because the API/state order did not match the HCL order.

```console
$ TF_CLI_CONFIG_FILE=terraformrc-v037.tfrc terraform plan -detailed-exitcode -input=false -no-color
jamfpro_policy.recon["charlie"]: Refreshing state... [id=10]
jamfpro_policy.recon["alpha"]: Refreshing state... [id=11]
jamfpro_policy.recon["bravo"]: Refreshing state... [id=9]
jamfpro_macos_onboarding_settings.migration_test: Refreshing state... [id=jamfpro_macos_onboarding_settings_singleton]

Terraform will perform the following actions:

  # jamfpro_macos_onboarding_settings.migration_test will be updated in-place
  ~ resource "jamfpro_macos_onboarding_settings" "migration_test" {
        id      = "jamfpro_macos_onboarding_settings_singleton"

      ~ onboarding_items {
          ~ entity_id = "9" -> "10"
          ~ priority  = 2 -> 3
        }
      ~ onboarding_items {
          ~ entity_id = "10" -> "11"
          ~ priority  = 3 -> 1
        }
      ~ onboarding_items {
          ~ entity_id = "11" -> "9"
          ~ priority  = 1 -> 2
        }
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

The command exited with Terraform detailed exit code `2`, confirming that `v0.37.0` still detected a diff.

#### Step 3: run the PR provider against the same existing multi-item state

```console
$ TF_CLI_CONFIG_FILE=terraformrc-pr.tfrc terraform plan -out=pr1077-multi-diff-migration.tfplan -input=false -no-color
jamfpro_policy.recon["charlie"]: Refreshing state... [id=10]
jamfpro_policy.recon["alpha"]: Refreshing state... [id=11]
jamfpro_policy.recon["bravo"]: Refreshing state... [id=9]
jamfpro_macos_onboarding_settings.migration_test: Refreshing state... [id=jamfpro_macos_onboarding_settings_singleton]

No changes. Your infrastructure matches the configuration.
```

```console
$ TF_CLI_CONFIG_FILE=terraformrc-pr.tfrc terraform apply -input=false -no-color pr1077-multi-diff-migration.tfplan
Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
```

After applying with the PR provider, the state was upgraded to `schema_version: 1` and retained all three onboarding items:

```json
{
  "type": "jamfpro_macos_onboarding_settings",
  "name": "migration_test",
  "instances": [
    {
      "schema_version": 1,
      "attributes": {
        "id": "jamfpro_macos_onboarding_settings_singleton",
        "enabled": true,
        "onboarding_items": [
          {
            "entity_id": "10",
            "entity_name": "tf-pr1077-onboarding-charlie-pr1077-migration-20260612171326",
            "id": "5",
            "priority": 3,
            "scope_description": "All computers",
            "self_service_entity_type": "OS_X_POLICY",
            "site_description": "None"
          },
          {
            "entity_id": "11",
            "entity_name": "tf-pr1077-onboarding-alpha-pr1077-migration-20260612171326",
            "id": "6",
            "priority": 1,
            "scope_description": "All computers",
            "self_service_entity_type": "OS_X_POLICY",
            "site_description": "None"
          },
          {
            "entity_id": "9",
            "entity_name": "tf-pr1077-onboarding-bravo-pr1077-migration-20260612171326",
            "id": "7",
            "priority": 2,
            "scope_description": "All computers",
            "self_service_entity_type": "OS_X_POLICY",
            "site_description": "None"
          }
        ]
      }
    }
  ]
}
```

#### Step 4: final refresh/plan with the PR provider

```console
$ TF_CLI_CONFIG_FILE=terraformrc-pr.tfrc terraform plan -detailed-exitcode -input=false -no-color
jamfpro_policy.recon["bravo"]: Refreshing state... [id=9]
jamfpro_policy.recon["charlie"]: Refreshing state... [id=10]
jamfpro_policy.recon["alpha"]: Refreshing state... [id=11]
jamfpro_macos_onboarding_settings.migration_test: Refreshing state... [id=jamfpro_macos_onboarding_settings_singleton]

No changes. Your infrastructure matches the configuration.
```

I also cleaned up the tenant after verification:

```console
$ TF_CLI_CONFIG_FILE=terraformrc-pr.tfrc terraform destroy -auto-approve -input=false -no-color
jamfpro_macos_onboarding_settings.migration_test: Destruction complete after 0s
jamfpro_policy.recon["alpha"]: Destruction complete after 0s
jamfpro_policy.recon["bravo"]: Destruction complete after 0s
jamfpro_policy.recon["charlie"]: Destruction complete after 0s

Destroy complete! Resources: 4 destroyed.
```

## Quality Checklist
- [x] I have reviewed my own code before requesting review
- [ ] I have verified there are no other open Pull Requests for the same update/change
- [ ] All CI/CD pipelines pass without errors or warnings
- [ ] My code follows the established style guidelines of this project
- [ ] My comments are used only when necessary, ideally where the code's purpose is not self explanatory
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have made corresponding changes to the README and other relevant documentation
- [x] My changes generate no new warnings in the targeted migration test

## Screenshots/Recordings (if appropriate)

The original recurring diff was:

```hcl
  # jamfpro_macos_onboarding_settings.onboarding will be updated in-place
  ~ resource "jamfpro_macos_onboarding_settings" "onboarding" {
        id      = "jamfpro_macos_onboarding_settings_singleton"
        # (1 unchanged attribute hidden)
      ~ onboarding_items {
          ~ entity_id                = "76" -> "373"
            id                       = "14"
          ~ priority                 = 3 -> 1
            # (4 unchanged attributes hidden)
        }
      ~ onboarding_items {
          ~ entity_id                = "134" -> "216"
            id                       = "15"
          ~ priority                 = 5 -> 2
            # (4 unchanged attributes hidden)
        }
      ~ onboarding_items {
          ~ entity_id                = "136" -> "76"
            id                       = "16"
          ~ priority                 = 4 -> 3
            # (4 unchanged attributes hidden)
        }
      ~ onboarding_items {
          ~ entity_id                = "216" -> "136"
            id                       = "17"
          ~ priority                 = 2 -> 4
            # (4 unchanged attributes hidden)
        }
      ~ onboarding_items {
          ~ entity_id                = "336" -> "134"
            id                       = "18"
          ~ priority                 = 6 -> 5
            # (4 unchanged attributes hidden)
        }
      ~ onboarding_items {
          ~ entity_id                = "353" -> "336"
            id                       = "19"
          ~ priority                 = 8 -> 6
            # (4 unchanged attributes hidden)
        }
      ~ onboarding_items {
          ~ entity_id                = "373" -> "416"
            id                       = "20"
          ~ priority                 = 1 -> 7
            # (4 unchanged attributes hidden)
        }
      ~ onboarding_items {
          ~ entity_id                = "416" -> "353"
            id                       = "21"
          ~ priority                 = 7 -> 8
            # (4 unchanged attributes hidden)
        }
    }
```

## Additional Notes

Existing users should not need to run `terraform state rm` or `terraform import` for this change. I verified the migration by creating schema version 0 state with `v0.37.0`, using three existing `onboarding_items`, then proving that `v0.37.0` still produced the repeated ordering diff. Running the PR provider against that same state produced no diff, upgraded `jamfpro_macos_onboarding_settings` to schema version 1, preserved all three items, and produced a clean follow-up plan.
