### PR TITLE
fix(webhook): defer smart_group_id validation when value is unknown

### DIFF
--- a/internal/services/webhook/resource_custom_diff.go
+++ b/internal/services/webhook/resource_custom_diff.go
@@ -59,6 +59,13 @@ func validateSmartGroupIDRequirement(_ context.Context, diff *schema.ResourceDif
 	// Check if the current event is in the list of required events
 	for _, reqEvent := range requiredEvents {
 		if event.(string) == reqEvent {
+			// When smart_group_id references another resource being created in
+			// the same apply (e.g. jamfpro_smart_computer_group_v2.this.id),
+			// the value is unknown at plan time. Defer validation until apply
+			// rather than incorrectly rejecting it as missing.
+			if !diff.NewValueKnown("smart_group_id") {
+				break
+			}
 			smartGroupID, smartGroupIDOk := diff.GetOk("smart_group_id")
 			if !smartGroupIDOk || smartGroupID == 0 {
 				return fmt.Errorf("in 'jamfpro_webhook.%s': when 'event' is set to '%s', 'smart_group_id' must be provided and must be a valid non-zero integer", resourceName, event)

--- a/testing/payloads/jamfpro_webhook/provider.tf
+++ b/testing/payloads/jamfpro_webhook/provider.tf
@@ -1,0 +1,108 @@
+terraform {
+  required_providers {
+    jamfpro = {
+      source = "terraform.local/local/jamfpro"
+      # Specifically 0.1.0
+      version = "0.1.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "3.4.3"
+    }
+  }
+}
+
+provider "jamfpro" {
+  jamfpro_instance_fqdn                = var.jamfpro_instance_fqdn
+  auth_method                          = var.jamfpro_auth_method
+  client_id                            = var.jamfpro_client_id
+  client_secret                        = var.jamfpro_client_secret
+  enable_client_sdk_logs               = var.enable_client_sdk_logs
+  client_sdk_log_export_path           = var.client_sdk_log_export_path
+  hide_sensitive_data                  = var.jamfpro_hide_sensitive_data
+  jamfpro_load_balancer_lock           = var.jamfpro_load_balancer_lock
+  token_refresh_buffer_period_seconds  = var.jamfpro_token_refresh_buffer_period_seconds
+  mandatory_request_delay_milliseconds = var.jamfpro_mandatory_request_delay_milliseconds
+}
+
+
+variable "jamfpro_instance_fqdn" {
+  description = "The Jamf Pro FQDN (fully qualified domain name). Example: https://mycompany.jamfcloud.com"
+  sensitive   = true
+}
+
+variable "jamfpro_auth_method" {
+  description = "Auth method chosen for Jamf. Options are 'basic' or 'oauth2'."
+  sensitive   = true
+  type        = string
+}
+
+variable "jamfpro_client_id" {
+  description = "The Jamf Pro Client ID for authentication."
+  sensitive   = true
+  type        = string
+}
+
+variable "jamfpro_client_secret" {
+  description = "The Jamf Pro Client Secret for authentication."
+  sensitive   = true
+  type        = string
+}
+
+variable "enable_client_sdk_logs" {
+  description = "Enable client SDK logs."
+  type        = bool
+  default     = false
+}
+
+variable "client_sdk_log_export_path" {
+  description = "Specify the path to export http client logs to."
+  type        = string
+  default     = ""
+}
+
+variable "jamfpro_hide_sensitive_data" {
+  description = "Define whether sensitive fields should be hidden in logs."
+  type        = bool
+  default     = true
+}
+
+variable "jamfpro_custom_cookies" {
+  description = "Custom cookies for the HTTP client."
+  type = list(object({
+    name  = string
+    value = string
+  }))
+  default = []
+}
+
+variable "jamfpro_load_balancer_lock" {
+  description = "Programmatically determines all available web app members in the load balancer and locks all instances of httpclient to the app for faster executions."
+  type        = bool
+  default     = true
+}
+
+variable "jamfpro_token_refresh_buffer_period_seconds" {
+  description = "The buffer period in seconds for token refresh."
+  type        = number
+  default     = 300
+}
+
+variable "jamfpro_mandatory_request_delay_milliseconds" {
+  description = "A mandatory delay after each request before returning to reduce high volume of requests in a short time."
+  type        = number
+  default     = 100
+}
+
+variable "testing_id" {
+  description = "Unique runtime id to differentiate testing objects between runs to avoid conflicts during cleanup phase"
+  type        = string
+}
+
+
+resource "random_id" "rng" {
+  keepers = {
+    first = "${timestamp()}"
+  }
+  byte_length = 8
+}

--- a/testing/payloads/jamfpro_webhook/webhook.tf
+++ b/testing/payloads/jamfpro_webhook/webhook.tf
@@ -1,0 +1,45 @@
+// ========================================================================== //
+// Webhooks
+// ========================================================================== //
+
+// ========================================================================== //
+// Smart-group-membership-change webhook with smart_group_id referenced from a
+// resource being created in the same apply. This is the case fixed by the
+// custom-diff change to validateSmartGroupIDRequirement — without that fix,
+// plan errors with "smart_group_id must be provided and must be a valid
+// non-zero integer" because diff.GetOk() can't distinguish unknown from unset.
+
+resource "jamfpro_smart_computer_group_v2" "webhook_target_group" {
+  name        = "tf-testing-${var.testing_id}-webhook-target-${random_id.rng.hex}"
+  description = "Smart group used as a webhook target in the same apply."
+  criteria {
+    name        = "Serial Number"
+    search_type = "not like"
+    value       = "C0"
+  }
+}
+
+resource "jamfpro_webhook" "smart_group_event_referenced_id" {
+  name               = "tf-testing-${var.testing_id}-sg-referenced-${random_id.rng.hex}"
+  enabled            = true
+  url                = "https://example.com/webhook/sg-referenced"
+  content_type       = "application/json"
+  event              = "SmartGroupComputerMembershipChange"
+  smart_group_id     = jamfpro_smart_computer_group_v2.webhook_target_group.id
+  connection_timeout = 5
+  read_timeout       = 5
+}
+
+// ========================================================================== //
+// Non-smart-group event — sanity check that the unrelated path still applies
+// without requiring a smart_group_id.
+
+resource "jamfpro_webhook" "non_smart_group_event" {
+  name               = "tf-testing-${var.testing_id}-inv-completed-${random_id.rng.hex}"
+  enabled            = true
+  url                = "https://example.com/webhook/inventory"
+  content_type       = "application/json"
+  event              = "ComputerInventoryCompleted"
+  connection_timeout = 5
+  read_timeout       = 5
+}


### PR DESCRIPTION
## Summary

Fixes #1085 — `jamfpro_webhook` cannot reference a `smart_group_id` from another resource being created in the same apply. `validateSmartGroupIDRequirement` runs at plan time and reads the value via `diff.GetOk("smart_group_id")`, which returns `0` / `false` for unknown values. The validator then rejects it as if the user had forgotten to set the field.

## Reproducer

```hcl
resource "jamfpro_smart_computer_group_v2" "unassigned" {
  name = "Devices Without Foo"
  criteria {
    name        = "Foo"
    search_type = "is"
    value       = ""
  }
}

resource "jamfpro_webhook" "on_membership_change" {
  name           = "Foo - Membership Change"
  enabled        = true
  url            = "https://example.com/webhook"
  content_type   = "application/json"
  event          = "SmartGroupComputerMembershipChange"
  smart_group_id = jamfpro_smart_computer_group_v2.unassigned.id
}
```

`terraform apply` errors at plan with:
> Error: in 'jamfpro_webhook.on_membership_change': when 'event' is set to 'SmartGroupComputerMembershipChange', 'smart_group_id' must be provided and must be a valid non-zero integer

## Fix

Use `schema.ResourceDiff.NewValueKnown("smart_group_id")` to detect the computed case and defer validation until apply, when the resolved value can be checked accurately. This is the standard Plugin SDK pattern for `CustomizeDiff` validators that need to handle references from other resources.

The "user forgot to set the field" path is unchanged — when the value is genuinely unset (not just unknown), `NewValueKnown` returns `true` and validation runs as before.

## Scope

The same pattern likely applies to `validateAuthenticationRequirements` for `username` / `password` if those are ever sourced from other resources, but `smart_group_id` is the practical blocker today. Happy to extend the fix in this PR or as a follow-up — whatever you prefer.

## Testing

- `go vet ./internal/services/webhook/...` clean
- `go build ./internal/services/webhook/...` clean
- No unit tests for `resource_custom_diff.go` exist in this provider; left it consistent with the surrounding code. Happy to add one if you'd like — let me know which test pattern you want me to follow.