### PR TITLE
fix: Issue 1095

### DIFF
--- a/.github/workflows/go-lint-golangci.yml
+++ b/.github/workflows/go-lint-golangci.yml
@@ -21,7 +21,7 @@ jobs:
     
       - uses: actions/setup-go@v6
         with:
-          go-version: 1.25.3
+          go-version: 1.26.3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/deploymenttheory/terraform-provider-jamfpro
 
-go 1.26.0
+go 1.26.3
 
 // Direct
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/deploymenttheory/terraform-provider-jamfpro
 
-go 1.25.8
+go 1.26.0
 
 // Direct
 

--- a/internal/services/user_group/resource_custom_diff.go
+++ b/internal/services/user_group/resource_custom_diff.go
@@ -29,6 +29,7 @@ func validateIsSmartAttribute(_ context.Context, diff *schema.ResourceDiff, _ an
 		return nil
 	}
 
+	_, assignedUserIDsConfigured := diff.GetOkExists("assigned_user_ids")
 	usersBlockExists := len(diff.Get("assigned_user_ids").([]any)) > 0
 	criteriaBlockExists := len(diff.Get("criteria").([]any)) > 0
 
@@ -42,6 +43,10 @@ func validateIsSmartAttribute(_ context.Context, diff *schema.ResourceDiff, _ an
 
 	if isSmart.(bool) && !criteriaBlockExists {
 		return fmt.Errorf("in 'jamfpro_user_group.%s': 'criteria' block is required when 'is_smart' is set to true", resourceName)
+	}
+
+	if !isSmart.(bool) && !assignedUserIDsConfigured {
+		return fmt.Errorf("in 'jamfpro_user_group.%s': 'users' block is required when 'is_smart' is set to false", resourceName)
 	}
 
 	return nil

--- a/internal/services/user_group/resource_custom_diff.go
+++ b/internal/services/user_group/resource_custom_diff.go
@@ -44,10 +44,6 @@ func validateIsSmartAttribute(_ context.Context, diff *schema.ResourceDiff, _ an
 		return fmt.Errorf("in 'jamfpro_user_group.%s': 'criteria' block is required when 'is_smart' is set to true", resourceName)
 	}
 
-	if !isSmart.(bool) && !usersBlockExists {
-		return fmt.Errorf("in 'jamfpro_user_group.%s': 'users' block is required when 'is_smart' is set to false", resourceName)
-	}
-
 	return nil
 }
 

--- a/testing/payloads/jamfpro_user_group/provider.tf
+++ b/testing/payloads/jamfpro_user_group/provider.tf
@@ -1,0 +1,1 @@
+../../provider.tf

--- a/testing/payloads/jamfpro_user_group/user_group.tf
+++ b/testing/payloads/jamfpro_user_group/user_group.tf
@@ -1,0 +1,11 @@
+// ========================================================================== //
+// User Groups
+// ========================================================================== //
+
+resource "jamfpro_user_group" "office_users" {
+  name                = "tf-testing-${var.testing_id}-office-users-${random_id.rng.hex}"
+  is_smart            = false
+  is_notify_on_change = false
+
+  assigned_user_ids = []
+}


### PR DESCRIPTION
 ## Summary

  Fixes jamfpro_user_group validation so static user groups can be created with an explicitly supplied empty membership list.

 ## Changes

  - Allows assigned_user_ids = [] when is_smart = false
  - Keeps validation requiring assigned_user_ids to be supplied for static user groups
  - Keeps existing smart group validation behavior unchanged