### PR TITLE
fix: Issue 1085

### DIFF
--- a/internal/services/user_group/resource_custom_diff.go
+++ b/internal/services/user_group/resource_custom_diff.go
@@ -29,6 +29,7 @@ func validateIsSmartAttribute(_ context.Context, diff *schema.ResourceDiff, _ an
 		return nil
 	}
 
+	_, assignedUserIDsConfigured := diff.GetOkExists("assigned_user_ids")
 	usersBlockExists := len(diff.Get("assigned_user_ids").([]any)) > 0
 	criteriaBlockExists := len(diff.Get("criteria").([]any)) > 0
 
@@ -42,6 +43,10 @@ func validateIsSmartAttribute(_ context.Context, diff *schema.ResourceDiff, _ an
 
 	if isSmart.(bool) && !criteriaBlockExists {
 		return fmt.Errorf("in 'jamfpro_user_group.%s': 'criteria' block is required when 'is_smart' is set to true", resourceName)
+	}
+
+	if !isSmart.(bool) && !assignedUserIDsConfigured {
+		return fmt.Errorf("in 'jamfpro_user_group.%s': 'users' block is required when 'is_smart' is set to false", resourceName)
 	}
 
 	return nil

--- a/internal/services/user_group/resource_custom_diff.go
+++ b/internal/services/user_group/resource_custom_diff.go
@@ -44,10 +44,6 @@ func validateIsSmartAttribute(_ context.Context, diff *schema.ResourceDiff, _ an
 		return fmt.Errorf("in 'jamfpro_user_group.%s': 'criteria' block is required when 'is_smart' is set to true", resourceName)
 	}
 
-	if !isSmart.(bool) && !usersBlockExists {
-		return fmt.Errorf("in 'jamfpro_user_group.%s': 'users' block is required when 'is_smart' is set to false", resourceName)
-	}
-
 	return nil
 }
 

--- a/internal/services/webhook/resource_custom_diff.go
+++ b/internal/services/webhook/resource_custom_diff.go
@@ -59,6 +59,10 @@ func validateSmartGroupIDRequirement(_ context.Context, diff *schema.ResourceDif
 	// Check if the current event is in the list of required events
 	for _, reqEvent := range requiredEvents {
 		if event.(string) == reqEvent {
+			if !diff.NewValueKnown("smart_group_id") {
+				break
+			}
+
 			smartGroupID, smartGroupIDOk := diff.GetOk("smart_group_id")
 			if !smartGroupIDOk || smartGroupID == 0 {
 				return fmt.Errorf("in 'jamfpro_webhook.%s': when 'event' is set to '%s', 'smart_group_id' must be provided and must be a valid non-zero integer", resourceName, event)


### PR DESCRIPTION
• ## Summary

  Closes #1085.

  - Updates `jamfpro_webhook` custom diff validation for smart-group webhook events.
  - Skips `smart_group_id` validation when Terraform marks the value as unknown during planning.
  - Preserves the existing validation error for known missing or zero `smart_group_id` values.