### PR TITLE
fix(profiles): stop double-escaping inner plist XML in payloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ website/vendor
 testing/data_sources/*
 .terraform.lock.hcl
 golangci-lint-report.sarif
+terraform-provider-jamfpro

--- a/internal/services/macos_configuration_profile_plist/resource_constructor.go
+++ b/internal/services/macos_configuration_profile_plist/resource_constructor.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/xml"
 	"fmt"
-	"html"
 	"log"
 	"strings"
 
@@ -81,7 +80,13 @@ func constructJamfProMacOSConfigurationProfilePlist(d *schema.ResourceData, mode
 	}
 
 	if mode != "update" {
-		resource.General.Payloads = html.EscapeString(d.Get("payloads").(string))
+		// encoding/xml escapes element text for us (& < > ' " → entities) when
+		// the outer request envelope is marshalled. Don't pre-escape — doing
+		// so causes inner-plist entities like &gt; to be doubled to &amp;gt;,
+		// which Jamf decodes only once on receive, leaving literal &gt;
+		// characters in the value that reach the device. See PR #627 / commit
+		// a02b2a29 for the original fix that was reverted in bb5238a9.
+		resource.General.Payloads = d.Get("payloads").(string)
 
 	} else if mode == "update" {
 		var existingPlist map[string]any
@@ -134,11 +139,14 @@ func constructJamfProMacOSConfigurationProfilePlist(d *schema.ResourceData, mode
 			return nil, fmt.Errorf("failed to encode plist payload with injected PayloadUUID and PayloadIdentifier: %v", err)
 		}
 
-		// Since we're embedding a Plist (which is XML) inside another XML document (the request),
-		// we need to properly correctly normalize the XML for the xml.MarshalIndent and also for jamf pro.
+		// The re-encoded plist is well-formed XML with entities like &gt; / &amp;
+		// already correctly representing their literal characters. encoding/xml
+		// will escape this string as element text when marshalling the outer
+		// request, producing the one and only level of XML escaping needed on
+		// the wire. Pre-escaping here would double-encode and survive Jamf's
+		// receive-side decode.
 		if buf.Len() > 0 {
-			unquotedContent := preMarshallingXMLPayloadUnescaping(buf.String())
-			resource.General.Payloads = preMarshallingXMLPayloadEscaping(unquotedContent)
+			resource.General.Payloads = buf.String()
 		}
 	}
 
@@ -150,19 +158,6 @@ func constructJamfProMacOSConfigurationProfilePlist(d *schema.ResourceData, mode
 	log.Printf("[DEBUG] Constructed Jamf Pro macOS Configuration Profile XML:\n%s\n", resourceXML)
 
 	return resource, nil
-}
-
-// preMarshallingXMLPayloadUnescaping unescapes content ready for jamf pro based on plist reqs
-func preMarshallingXMLPayloadUnescaping(input string) string {
-	input = strings.ReplaceAll(input, "&#34;", "\"")
-	return input
-}
-
-// preMarshallingXMLPayloadEscaping ensures that the XML marshaller (used in xml.MarshalIndent)
-// doesn't choke on special XML characters (&) inside the payload
-func preMarshallingXMLPayloadEscaping(input string) string {
-	input = strings.ReplaceAll(input, "&", "&amp;")
-	return input
 }
 
 // constructMacOSConfigurationProfileSubsetScope reads the scope map and calls helpers

--- a/internal/services/macos_configuration_profile_plist_generator/resource_constructor.go
+++ b/internal/services/macos_configuration_profile_plist_generator/resource_constructor.go
@@ -4,7 +4,6 @@ package macos_configuration_profile_plist_generator
 import (
 	"encoding/xml"
 	"fmt"
-	"html"
 	"log"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
@@ -32,7 +31,10 @@ func constructJamfProMacOSConfigurationProfilesPlistGenerator(d *schema.Resource
 			Level:              d.Get("level").(string),
 			UUID:               d.Get("uuid").(string),
 			RedeployOnUpdate:   d.Get("redeploy_on_update").(string),
-			Payloads:           html.EscapeString(plistXML),
+			// Pass the plist XML through unescaped — encoding/xml escapes element
+			// text on outer-envelope marshalling. See macos_configuration_profile_plist
+			// constructor for the full rationale.
+			Payloads: plistXML,
 		},
 	}
 

--- a/internal/services/mobile_device_configuration_profile_plist/resource_constructor.go
+++ b/internal/services/mobile_device_configuration_profile_plist/resource_constructor.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/xml"
 	"fmt"
-	"html"
 	"log"
 	"strings"
 
@@ -64,7 +63,13 @@ func constructJamfProMobileDeviceConfigurationProfilePlist(d *schema.ResourceDat
 
 	// Handle Payloads based on mode
 	if mode != "update" {
-		resource.General.Payloads = html.EscapeString(d.Get("payloads").(string))
+		// encoding/xml escapes element text (& < > ' " → entities) when the
+		// outer request envelope is marshalled. Don't pre-escape — doing so
+		// double-encodes inner-plist entities like &gt; to &amp;gt;, which
+		// Jamf decodes only once on receive, leaving literal &gt; characters
+		// in the value that reach the device. See PR #627 / commit a02b2a29
+		// for the original fix that was reverted in bb5238a9.
+		resource.General.Payloads = d.Get("payloads").(string)
 	} else if mode == "update" {
 		var existingPlist map[string]any
 		var newPlist map[string]any
@@ -77,8 +82,10 @@ func constructJamfProMobileDeviceConfigurationProfilePlist(d *schema.ResourceDat
 			return nil, fmt.Errorf("failed to get existing mobile device configuration profile by ID %s for update: %v", resourceID, err)
 		}
 
+		// Jamf returns the inner plist single-escaped (encoding/xml-level only)
+		// once we stop double-escaping on the write side, so no html.UnescapeString
+		// is needed here — howett.net/plist's decoder handles standard XML entities.
 		existingPayload := existingProfile.General.Payloads
-		existingPayload = html.UnescapeString(existingPayload)
 		if err := plist.NewDecoder(strings.NewReader(existingPayload)).Decode(&existingPlist); err != nil {
 			return nil, fmt.Errorf("failed to decode existing plist payload from Jamf Pro for update (ID: %s): %v\nPayload attempted:\n%s", resourceID, err, existingPayload)
 		}
@@ -114,11 +121,11 @@ func constructJamfProMobileDeviceConfigurationProfilePlist(d *schema.ResourceDat
 			return nil, fmt.Errorf("failed to encode updated plist payload: %v", err)
 		}
 
-		// Since we're embedding a Plist (which is XML) inside another XML document (the request),
-		// we need to properly correctly normalize the XML for the xml.MarshalIndent and also for jamf pro.
+		// The re-encoded plist is well-formed XML; let encoding/xml escape it
+		// as element text when marshalling the outer envelope. See create-mode
+		// note above for why we don't pre-escape.
 		if buf.Len() > 0 {
-			unquotedContent := preMarshallingXMLPayloadUnescaping(buf.String())
-			resource.General.Payloads = preMarshallingXMLPayloadEscaping(unquotedContent)
+			resource.General.Payloads = buf.String()
 		}
 	}
 
@@ -130,19 +137,6 @@ func constructJamfProMobileDeviceConfigurationProfilePlist(d *schema.ResourceDat
 	log.Printf("[DEBUG] Constructed Jamf Pro Mobile Device Configuration Profile XML:\n%s\n", string(resourceXML))
 
 	return resource, nil
-}
-
-// preMarshallingXMLPayloadUnescaping unescapes content ready for jamf pro based on plist reqs
-func preMarshallingXMLPayloadUnescaping(input string) string {
-	input = strings.ReplaceAll(input, "&#34;", "\"")
-	return input
-}
-
-// preMarshallingXMLPayloadEscaping ensures that the XML marshaller (used in xml.MarshalIndent)
-// doesn't choke on special XML characters (&) inside the payload
-func preMarshallingXMLPayloadEscaping(input string) string {
-	input = strings.ReplaceAll(input, "&", "&amp;")
-	return input
 }
 
 // constructMobileDeviceConfigurationProfileSubsetScope constructs the scope using TypeSet from schema.


### PR DESCRIPTION
# Pull Request Description

## Summary
The `macos_configuration_profile_plist`, `macos_configuration_profile_plist_generator`, and `mobile_device_configuration_profile_plist` resources pre-escape the inner plist XML with `html.EscapeString` (and a naïve `& → &amp;` helper on the update path) before assigning it to `resource.General.Payloads`. The SDK then marshals the outer request envelope with `encoding/xml`, which escapes element text on its own. Net result: two layers of escaping go out, Jamf decodes only one on receive, and the inner plist Jamf stores ends up containing entities like `&amp;gt;` where the source had `&gt;`. That extra layer survives all the way to the device.

### Issue Reference
Re-opens the symptom of #624. The fix for that issue was intended but did not land in its working form — see "Motivation" below.

### Motivation and Context

Easiest to see the bug with a Santa CEL `StaticRule`. Using the timestamp example straight from [northpole.dev's CEL docs](https://northpole.dev/features/binary-authorization/#cel), the source `CELExpr` is:

```
target.signing_time >= timestamp('2025-05-31T00:00:00Z')
```

When this profile is uploaded by the current provider and then installed on a real macOS device, `system_profiler SPConfigurationProfileDataType` shows the value as:

```
CELExpr = "target.signing_time &gt;= timestamp(&#39;2025-05-31T00:00:00Z&#39;)"
```

— the literal six characters `&gt;= ` where the operator `>=` should be, and `&#39;` where the single quotes should be. Santa's CEL parser fails on the resulting string and the rule is effectively a no-op. The same root cause corrupts any other special characters in payload string values: `<`, `>`, `&`, `'`, `"`, and `\n` (the last shows up as a literal `&#xA;` in `CustomMsg` strings that contain line breaks).

Git archaeology:

- #624 was opened reporting the symptom for `EventDetailURL` values containing `&amp;`.
- PR #627 was opened to fix it. Commit `a02b2a29` had the correct fix: drop the manual escape, let `encoding/xml` handle it.
- Three days later, in the same PR, commit `bb5238a9` reverted that and re-introduced `html.EscapeString` on create plus a naïve `preMarshallingXMLPayloadEscaping` helper on update, with an asymmetric `preMarshallingXMLPayloadUnescaping` that special-cased only `&#34;` → `"`.
- PR #627 merged in that broken state and the issue was closed as completed. The asymmetric unescape made `"` round-trip correctly (by accident) which is probably why the regression wasn't caught — but every other entity (`&gt;`, `&#39;`, `&#xA;`, `&lt;`, `&amp;`) doubles up and reaches the device broken.

### Why `encoding/xml` is sufficient on its own

The Jamf integration in `go-api-http-client-integrations` serializes requests with `xml.Marshal(body)` (`jamfprointegration/marshall.go`). `xml.Marshal` calls `escapeText` on string fields, which escapes `& < > ' "` to entities — exactly one level. That's precisely what's needed to embed inner-plist text inside `<payloads>...</payloads>`. Any pre-escaping in the constructor doubles up.

The fix is symmetric across the wire:

- writes produce single-escaped element text
- Jamf serves single-escaped element text back
- the SDK's `encoding/xml` decoder undoes the one level
- `howett.net/plist` parses the resulting standard plist XML natively

### Changes
- Remove `html.EscapeString` from create paths in all three resources.
- Remove the `preMarshallingXMLPayloadEscaping` / `preMarshallingXMLPayloadUnescaping` helpers from the macos and mobile_device update paths; assign `buf.String()` directly.
- Remove the matching `html.UnescapeString` workaround on the mobile_device update *read* path — no longer needed once writes stop double-escaping; leaving it would over-decode legitimate single-escaped values returned by Jamf and corrupt the plist parse.
- Drop the now-unused `"html"` import from all three files.

### Dependencies
None. No SDK or third-party dependency changes.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update (Wiki/README/Code comments)
- [ ] ♻️ Refactor (code improvement without functional changes)
- [ ] 🎨 Style update (formatting, renaming)
- [ ] 🔧 Configuration change
- [ ] 📦 Dependency update

## Testing
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added integration tests following the testing implementation guide
- [x] I have tested this code in the following browsers/environments: see below

Test status detail:

- `go build ./...` clean.
- `go test ./internal/services/macos_configuration_profile_plist/... ./internal/services/mobile_device_configuration_profile_plist/... ./internal/services/macos_configuration_profile_plist_generator/...` — one failure, `TestDiffSuppressEquivalentPayloads/Validation_disabled_should_not_suppress`. **Pre-existing on `main`** (verified by stashing this PR's changes and re-running) — unrelated.
- End-to-end verification: applied a `jamfpro_macos_configuration_profile_plist` resource containing a Santa CEL rule (the timestamp expression from northpole.dev quoted above) and installed the resulting profile on a real macOS device via Jamf MDM. `system_profiler SPConfigurationProfileDataType` now shows the operator `>=` and `'` literally where the broken provider showed `&gt;=` and `&#39;`.

A regression test that round-trips a payload containing `>`, `<`, `&`, `'`, `"`, and a newline through the constructor (asserting only one level of XML escaping leaves the constructor) would be a useful follow-up but is not included here — happy to add it in a follow-up if the maintainers would like.

## Quality Checklist
- [x] I have reviewed my own code before requesting review
- [x] I have verified there are no other open Pull Requests for the same update/change
- [ ] All CI/CD pipelines pass without errors or warnings *(will be visible once the PR opens)*
- [x] My code follows the established style guidelines of this project
- [x] My comments are used only when necessary
- [x] I have added necessary documentation (in-line code comments explaining the encoding/xml reliance)
- [ ] I have made corresponding changes to the README and other relevant documentation *(no README changes needed)*
- [x] My changes generate no new warnings

## Screenshots/Recordings (if appropriate)

Source `CELExpr` (the timestamp example from northpole.dev):

```
target.signing_time >= timestamp('2025-05-31T00:00:00Z')
```

On-device `system_profiler SPConfigurationProfileDataType` output:

**Before (current `main`, broken):**

```
CELExpr = "target.signing_time &gt;= timestamp(&#39;2025-05-31T00:00:00Z&#39;)"
```

**After (this fix):**

```
CELExpr = "target.signing_time >= timestamp('2025-05-31T00:00:00Z')"
```

## Additional Notes

Maintainer note: it would be worth re-opening #624 (or leaving a note on the closed thread) since users hitting that symptom are still hitting it on current `main`. The asymmetric `&#34;` → `"` carve-out made `"` work by accident, which is what probably hid the regression. If you'd like, I'll add a test guarding against this specific double-escape on a follow-up PR — let me know which fixture/test style you prefer.