### PR TITLE
fix: defer cloud_distribution_point config validation on unknown values

### DIFF
--- a/internal/services/cloud_distribution_point/resource_validate.go
+++ b/internal/services/cloud_distribution_point/resource_validate.go
@@ -32,15 +32,15 @@ func (cloudDistributionPointConfigValidator) ValidateResource(ctx context.Contex
 	resp.Diagnostics.Append(validateCloudDistributionPointPlan(&data)...)
 }
 
-// validateCloudDistributionPointPlan validates the provided cloud distribution point resource model.
+// validateCloudDistributionPointPlan validates the provided cloud distribution
+// point resource model. It runs at config time via ValidateResourceConfig, where
+// Terraform passes unknown values for any attribute sourced from a variable,
+// for_each, count, or another resource. Unknown means "not resolvable yet", not
+// "missing", so unknown values are deferred to plan/apply; only a truly null
+// (omitted) value is a config error.
 func validateCloudDistributionPointPlan(data *cloudDistributionPointResourceModel) diag.Diagnostics {
 	var diags diag.Diagnostics
 
-	// Config-time validation runs via ValidateResourceConfig, where Terraform
-	// passes unknown values for any attribute sourced from a variable, for_each,
-	// count, or another resource. Unknown means "not resolvable yet", not
-	// "missing", so defer cross-attribute validation to plan/apply rather than
-	// erroring here. Only a truly null (omitted) value is a config error.
 	if data.CdnType.IsUnknown() || data.Master.IsUnknown() {
 		return diags
 	}

--- a/internal/services/cloud_distribution_point/resource_validate.go
+++ b/internal/services/cloud_distribution_point/resource_validate.go
@@ -36,7 +36,16 @@ func (cloudDistributionPointConfigValidator) ValidateResource(ctx context.Contex
 func validateCloudDistributionPointPlan(data *cloudDistributionPointResourceModel) diag.Diagnostics {
 	var diags diag.Diagnostics
 
-	if data.CdnType.IsNull() || data.CdnType.IsUnknown() {
+	// Config-time validation runs via ValidateResourceConfig, where Terraform
+	// passes unknown values for any attribute sourced from a variable, for_each,
+	// count, or another resource. Unknown means "not resolvable yet", not
+	// "missing", so defer cross-attribute validation to plan/apply rather than
+	// erroring here. Only a truly null (omitted) value is a config error.
+	if data.CdnType.IsUnknown() || data.Master.IsUnknown() {
+		return diags
+	}
+
+	if data.CdnType.IsNull() {
 		diags.AddError(
 			"Missing CDN Type",
 			"Attribute cdn_type must be provided to manage the cloud distribution point.",
@@ -44,7 +53,7 @@ func validateCloudDistributionPointPlan(data *cloudDistributionPointResourceMode
 		return diags
 	}
 
-	if data.Master.IsNull() || data.Master.IsUnknown() {
+	if data.Master.IsNull() {
 		diags.AddError(
 			"Missing Master Flag",
 			"Attribute master must be provided to manage the cloud distribution point.",
@@ -101,11 +110,19 @@ func validateCloudDistributionPointPlan(data *cloudDistributionPointResourceMode
 	}
 
 	return diags
-} // requireStringAttribute checks that a string attribute is set when required.
+}
+
+// requireStringAttribute checks that a string attribute is set when required.
+// Unknown values are deferred (not an error): the validator runs at config time
+// where variable/for_each-driven values are unknown and resolved later.
 func requireStringAttribute(name string, value types.String, cdnType string) diag.Diagnostics {
 	var diags diag.Diagnostics
 
-	if value.IsNull() || value.IsUnknown() || value.ValueString() == "" {
+	if value.IsUnknown() {
+		return diags
+	}
+
+	if value.IsNull() || value.ValueString() == "" {
 		diags.AddError(
 			fmt.Sprintf("Missing %s", name),
 			fmt.Sprintf("Attribute %s must be set when cdn_type is %s.", name, cdnType),
@@ -116,10 +133,15 @@ func requireStringAttribute(name string, value types.String, cdnType string) dia
 }
 
 // requireBoolAttribute checks that a bool attribute is set when required.
+// Unknown values are deferred (not an error); see requireStringAttribute.
 func requireBoolAttribute(name string, value types.Bool, cdnType string) diag.Diagnostics {
 	var diags diag.Diagnostics
 
-	if value.IsNull() || value.IsUnknown() {
+	if value.IsUnknown() {
+		return diags
+	}
+
+	if value.IsNull() {
 		diags.AddError(
 			fmt.Sprintf("Missing %s", name),
 			fmt.Sprintf("Attribute %s must be explicitly set when cdn_type is %s.", name, cdnType),
@@ -130,10 +152,15 @@ func requireBoolAttribute(name string, value types.Bool, cdnType string) diag.Di
 }
 
 // requireIntAttribute checks that an int attribute is set when required.
+// Unknown values are deferred (not an error); see requireStringAttribute.
 func requireIntAttribute(name string, value types.Int64, cdnType string) diag.Diagnostics {
 	var diags diag.Diagnostics
 
-	if value.IsNull() || value.IsUnknown() {
+	if value.IsUnknown() {
+		return diags
+	}
+
+	if value.IsNull() {
 		diags.AddError(
 			fmt.Sprintf("Missing %s", name),
 			fmt.Sprintf("Attribute %s must be provided when cdn_type is %s.", name, cdnType),

--- a/internal/services/cloud_distribution_point/resource_validate_test.go
+++ b/internal/services/cloud_distribution_point/resource_validate_test.go
@@ -1,0 +1,149 @@
+package cloud_distribution_point
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// baseModel returns a model with every attribute null. Tests override only the
+// fields they exercise.
+func baseModel() cloudDistributionPointResourceModel {
+	return cloudDistributionPointResourceModel{
+		CdnType:                 types.StringNull(),
+		Master:                  types.BoolNull(),
+		Username:                types.StringNull(),
+		Password:                types.StringNull(),
+		Directory:               types.StringNull(),
+		UploadURL:               types.StringNull(),
+		DownloadURL:             types.StringNull(),
+		SecondaryAuthRequired:   types.BoolNull(),
+		SecondaryAuthStatusCode: types.Int64Null(),
+		SecondaryAuthTimeToLive: types.Int64Null(),
+		RequireSignedUrls:       types.BoolNull(),
+		KeyPairID:               types.StringNull(),
+		ExpirationSeconds:       types.Int64Null(),
+		PrivateKey:              types.StringNull(),
+	}
+}
+
+func TestValidateCloudDistributionPointPlan(t *testing.T) {
+	tests := []struct {
+		name      string
+		mutate    func(m *cloudDistributionPointResourceModel)
+		wantError bool
+		// wantSummary, when set, must appear in at least one error summary.
+		wantSummary string
+	}{
+		{
+			// Regression: cdn_type sourced from a variable / for_each is unknown
+			// at config-validation time and must not error. See issue #1110.
+			name: "unknown cdn_type is deferred, not rejected",
+			mutate: func(m *cloudDistributionPointResourceModel) {
+				m.CdnType = types.StringUnknown()
+				m.Master = types.BoolValue(true)
+			},
+			wantError: false,
+		},
+		{
+			name: "unknown master is deferred, not rejected",
+			mutate: func(m *cloudDistributionPointResourceModel) {
+				m.CdnType = types.StringValue(cdnTypeJamfCloud)
+				m.Master = types.BoolUnknown()
+			},
+			wantError: false,
+		},
+		{
+			name: "null cdn_type is a config error",
+			mutate: func(m *cloudDistributionPointResourceModel) {
+				m.CdnType = types.StringNull()
+				m.Master = types.BoolValue(true)
+			},
+			wantError:   true,
+			wantSummary: "Missing CDN Type",
+		},
+		{
+			name: "null master is a config error",
+			mutate: func(m *cloudDistributionPointResourceModel) {
+				m.CdnType = types.StringValue(cdnTypeJamfCloud)
+				m.Master = types.BoolNull()
+			},
+			wantError:   true,
+			wantSummary: "Missing Master Flag",
+		},
+		{
+			name: "valid jamf cloud config passes",
+			mutate: func(m *cloudDistributionPointResourceModel) {
+				m.CdnType = types.StringValue(cdnTypeJamfCloud)
+				m.Master = types.BoolValue(true)
+			},
+			wantError: false,
+		},
+		{
+			// Akamai requires username/password/etc., but when those are unknown
+			// (variable-driven) validation is deferred rather than failing.
+			name: "akamai with unknown required attributes is deferred",
+			mutate: func(m *cloudDistributionPointResourceModel) {
+				m.CdnType = types.StringValue(cdnTypeAkamai)
+				m.Master = types.BoolValue(true)
+				m.Username = types.StringUnknown()
+				m.Password = types.StringUnknown()
+				m.Directory = types.StringUnknown()
+				m.UploadURL = types.StringUnknown()
+				m.DownloadURL = types.StringUnknown()
+				m.SecondaryAuthRequired = types.BoolUnknown()
+			},
+			wantError: false,
+		},
+		{
+			// Known-but-missing required attributes for a CDN type still error,
+			// proving validation is not wholesale skipped.
+			name: "akamai with known-missing required attributes still errors",
+			mutate: func(m *cloudDistributionPointResourceModel) {
+				m.CdnType = types.StringValue(cdnTypeAkamai)
+				m.Master = types.BoolValue(true)
+			},
+			wantError:   true,
+			wantSummary: "Missing username",
+		},
+		{
+			// Attributes invalid for the chosen CDN type are still rejected when
+			// they carry a known value.
+			name: "attribute not valid for cdn type errors",
+			mutate: func(m *cloudDistributionPointResourceModel) {
+				m.CdnType = types.StringValue(cdnTypeJamfCloud)
+				m.Master = types.BoolValue(true)
+				m.Username = types.StringValue("someone")
+			},
+			wantError:   true,
+			wantSummary: "Attribute username Is Not Valid For CDN Type",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := baseModel()
+			tt.mutate(&m)
+
+			diags := validateCloudDistributionPointPlan(&m)
+
+			if got := diags.HasError(); got != tt.wantError {
+				t.Fatalf("HasError() = %v, want %v (diags: %v)", got, tt.wantError, diags)
+			}
+
+			if tt.wantSummary != "" {
+				found := false
+				for _, d := range diags.Errors() {
+					if strings.Contains(d.Summary(), tt.wantSummary) {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Fatalf("expected an error summary containing %q, got %v", tt.wantSummary, diags)
+				}
+			}
+		})
+	}
+}

--- a/testing/payloads/jamfpro_cloud_distribution_point/cloud_distribution_point.tf
+++ b/testing/payloads/jamfpro_cloud_distribution_point/cloud_distribution_point.tf
@@ -1,0 +1,13 @@
+// ========================================================================== //
+// Cloud Distribution Point
+// ========================================================================== //
+
+// JCDS (Jamf Cloud Distribution Service) backed cloud distribution point set as
+// the principal (master) distribution point. JAMF_CLOUD requires no CDN
+// credentials, so this is the minimal create/teardown fixture; terraform test
+// applies it and destroys it at the end of the run.
+
+resource "jamfpro_cloud_distribution_point" "jcds" {
+  cdn_type = "JAMF_CLOUD"
+  master   = true
+}

--- a/testing/payloads/jamfpro_cloud_distribution_point/provider.tf
+++ b/testing/payloads/jamfpro_cloud_distribution_point/provider.tf
@@ -1,0 +1,108 @@
+terraform {
+  required_providers {
+    jamfpro = {
+      source = "terraform.local/local/jamfpro"
+      # Specifically 0.1.0
+      version = "0.1.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "3.4.3"
+    }
+  }
+}
+
+provider "jamfpro" {
+  jamfpro_instance_fqdn                = var.jamfpro_instance_fqdn
+  auth_method                          = var.jamfpro_auth_method
+  client_id                            = var.jamfpro_client_id
+  client_secret                        = var.jamfpro_client_secret
+  enable_client_sdk_logs               = var.enable_client_sdk_logs
+  client_sdk_log_export_path           = var.client_sdk_log_export_path
+  hide_sensitive_data                  = var.jamfpro_hide_sensitive_data
+  jamfpro_load_balancer_lock           = var.jamfpro_load_balancer_lock
+  token_refresh_buffer_period_seconds  = var.jamfpro_token_refresh_buffer_period_seconds
+  mandatory_request_delay_milliseconds = var.jamfpro_mandatory_request_delay_milliseconds
+}
+
+
+variable "jamfpro_instance_fqdn" {
+  description = "The Jamf Pro FQDN (fully qualified domain name). Example: https://mycompany.jamfcloud.com"
+  sensitive   = true
+}
+
+variable "jamfpro_auth_method" {
+  description = "Auth method chosen for Jamf. Options are 'basic' or 'oauth2'."
+  sensitive   = true
+  type        = string
+}
+
+variable "jamfpro_client_id" {
+  description = "The Jamf Pro Client ID for authentication."
+  sensitive   = true
+  type        = string
+}
+
+variable "jamfpro_client_secret" {
+  description = "The Jamf Pro Client Secret for authentication."
+  sensitive   = true
+  type        = string
+}
+
+variable "enable_client_sdk_logs" {
+  description = "Enable client SDK logs."
+  type        = bool
+  default     = false
+}
+
+variable "client_sdk_log_export_path" {
+  description = "Specify the path to export http client logs to."
+  type        = string
+  default     = ""
+}
+
+variable "jamfpro_hide_sensitive_data" {
+  description = "Define whether sensitive fields should be hidden in logs."
+  type        = bool
+  default     = true
+}
+
+variable "jamfpro_custom_cookies" {
+  description = "Custom cookies for the HTTP client."
+  type = list(object({
+    name  = string
+    value = string
+  }))
+  default = []
+}
+
+variable "jamfpro_load_balancer_lock" {
+  description = "Programmatically determines all available web app members in the load balancer and locks all instances of httpclient to the app for faster executions."
+  type        = bool
+  default     = true
+}
+
+variable "jamfpro_token_refresh_buffer_period_seconds" {
+  description = "The buffer period in seconds for token refresh."
+  type        = number
+  default     = 300
+}
+
+variable "jamfpro_mandatory_request_delay_milliseconds" {
+  description = "A mandatory delay after each request before returning to reduce high volume of requests in a short time."
+  type        = number
+  default     = 100
+}
+
+variable "testing_id" {
+  description = "Unique runtime id to differentiate testing objects between runs to avoid conflicts during cleanup phase"
+  type        = string
+}
+
+
+resource "random_id" "rng" {
+  keepers = {
+    first = "${timestamp()}"
+  }
+  byte_length = 8
+}


### PR DESCRIPTION
# Pull Request Description

## Summary
Fixes the `jamfpro_cloud_distribution_point` config-time validator so it defers on **unknown** values instead of erroring. Today the validator rejects unknown `cdn_type`/`master` (and CDN-required sub-attributes), which makes the resource unusable from anything other than hard-coded literals.

### Issue Reference
Fixes #1110

### Motivation and Context
- `validateCloudDistributionPointPlan` runs as a `resource.ConfigValidator` (`resource_schema.go` → `ConfigValidators()`), i.e. at config time via `ValidateResourceConfig`.
- Terraform invokes config validation with **unknown** values for any attribute sourced from a variable, `for_each`, `count`, or another resource.
- The validator did `if data.CdnType.IsNull() || data.CdnType.IsUnknown()` → `AddError("Missing CDN Type")` (same for `master`), so `terraform validate`/`plan` failed for every non-literal config. Only a hard-coded literal `cdn_type` survived — making a reusable wrapper module impossible.
- Unknown means "not resolvable yet", not "missing". A config-time validator should defer on unknown and validate once the value is known. The existing `attributeAllowedOnlyForCdns` helper already does exactly this; this PR makes the top-level `cdn_type`/`master` checks and the `require*` helpers consistent with it.

**Before** (`var`/`for_each`-driven config):
```
Error: Missing CDN Type
Attribute cdn_type must be provided to manage the cloud distribution point.
```
**After:** unknown values are deferred to plan/apply; known-value validation is unchanged.

### Dependencies
- None. No schema, API, or dependency changes.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Testing
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Added `resource_validate_test.go` (table-driven, stdlib `testing`) covering:
- unknown `cdn_type` / `master` → deferred, no error (regression for #1110)
- null `cdn_type` / `master` → config error (unchanged)
- valid `JAMF_CLOUD` config → passes
- `AKAMAI` with unknown required attributes → deferred
- `AKAMAI` with known-missing required attributes → still errors (validation not wholesale skipped)
- attribute set for an incompatible CDN type → still errors

```
$ go test ./internal/services/cloud_distribution_point/ -run TestValidateCloudDistributionPointPlan -v
--- PASS: TestValidateCloudDistributionPointPlan (8 subtests)
ok      github.com/deploymenttheory/terraform-provider-jamfpro/internal/services/cloud_distribution_point
```
`gofmt`, `go build`, and `go vet` are clean for the package. Integration tests not run (require live Jamf Pro credentials); this change is config-time-only and covered by unit tests.

## Quality Checklist
- [x] I have reviewed my own code before requesting review
- [x] I have verified there are no other open Pull Requests for the same update/change
- [x] My code follows the established style guidelines of this project
- [x] My comments are used only where the code's purpose is not self-explanatory
- [x] My changes generate no new warnings

## Additional Notes
The fix has two parts, both "defer on unknown, error only on null":
1. Top-level `cdn_type`/`master` guards — resolves the reported repro (module/variable-driven `cdn_type`).
2. `requireStringAttribute` / `requireBoolAttribute` / `requireIntAttribute` — so CDN-required sub-attributes (e.g. Akamai `directory`, S3 `private_key`) can also be variable-driven without breaking `terraform validate`.

Also tidied a stray inline comment that had merged onto the closing brace of `validateCloudDistributionPointPlan`.
