### PR TITLE
ci: opt in to fork PR checkout for pull_request_target workflows

### DIFF
--- a/.github/workflows/provider-generate-docs.yml
+++ b/.github/workflows/provider-generate-docs.yml
@@ -27,6 +27,9 @@ jobs:
     - uses: actions/checkout@v7
       with:
         ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.ref }}
+        # Required by actions/checkout@v7 to check out fork PR code under
+        # pull_request_target. See https://gh.io/securely-using-pull_request_target
+        allow-unsafe-pr-checkout: true
 
     - uses: actions/setup-go@v6
       with:

--- a/.github/workflows/provider-integration-test.yml
+++ b/.github/workflows/provider-integration-test.yml
@@ -44,6 +44,9 @@ jobs:
           ref: ${{ env.REF_TO_CHECKOUT }}
           # Required by actions/checkout@v7 to check out fork PR code under
           # pull_request_target. See https://gh.io/securely-using-pull_request_target
+          # This means this workflow will run with the base repository's GITHUB_TOKEN
+          # By fetching and executing a fork's code, we must validate carefully the pr
+          # because this can lead to "pwn request" vulnerabilities.
           allow-unsafe-pr-checkout: true
 
 

--- a/.github/workflows/provider-integration-test.yml
+++ b/.github/workflows/provider-integration-test.yml
@@ -42,6 +42,9 @@ jobs:
         with:
           repository: deploymenttheory/terraform-provider-jamfpro
           ref: ${{ env.REF_TO_CHECKOUT }}
+          # Required by actions/checkout@v7 to check out fork PR code under
+          # pull_request_target. See https://gh.io/securely-using-pull_request_target
+          allow-unsafe-pr-checkout: true
 
 
       - name: Compile Provider Binary


### PR DESCRIPTION
## Summary
`actions/checkout@v7` now refuses to check out fork pull request code from a `pull_request_target` workflow unless `allow-unsafe-pr-checkout: true` is set on the checkout step:

> Error: Refusing to check out fork pull request code from a 'pull_request_target' workflow. ... set 'allow-unsafe-pr-checkout: true' on the actions/checkout step.

This blocks fork PR CI (e.g. the integration tests). This adds the opt-in to the two affected `pull_request_target` workflows so fork PR CI runs again:

- `provider-integration-test.yml`
- `provider-generate-docs.yml`

Must land on `main` because `pull_request_target` workflows execute the workflow definition from the base branch.

## ⚠️ Security note
These workflows execute **fork-provided code with the base repo's `GITHUB_TOKEN` and secrets** (e.g. the testing Jamf credentials). Re-enabling this is the "pwn request" risk the warning describes — a malicious fork PR could attempt to exfiltrate those secrets. This restores the project's pre-checkout-v7 behaviour; longer term, consider gating the secret-using job behind a manual approval / `environment` protection rule or a maintainer label.

See https://gh.io/securely-using-pull_request_target