### PR TITLE
feat(sso_settings): add importer to support terraform import

### DIFF
--- a/examples/resources/jamfpro_sso_settings/resource.tf
+++ b/examples/resources/jamfpro_sso_settings/resource.tf
@@ -1,3 +1,7 @@
+# SSO settings is a singleton configuration that always exists in Jamf Pro.
+# Import the current configuration into Terraform state with:
+# terraform import jamfpro_sso_settings.google_example jamfpro_sso_settings_singleton
+
 resource "jamfpro_sso_settings" "google_example" {
   sso_enabled                                          = true
   configuration_type                                   = "SAML"

--- a/internal/services/sso_settings/resource_schema.go
+++ b/internal/services/sso_settings/resource_schema.go
@@ -22,6 +22,9 @@ func ResourceJamfProSsoSettings() *schema.Resource {
 			Update: schema.DefaultTimeout(1 * time.Minute),
 			Delete: schema.DefaultTimeout(1 * time.Minute),
 		},
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
 		Schema: map[string]*schema.Schema{
 			"sso_enabled": {
 				Type:        schema.TypeBool,


### PR DESCRIPTION
# Pull Request Description

## Summary
Adds an `Importer` to the `jamfpro_sso_settings` resource so an existing Jamf Pro SSO configuration can be adopted with `terraform import` (or an `import` block), matching the pattern already used by every other singleton configuration resource in the provider.

### Issue Reference
No open issue — happy to file one if you'd like this tracked separately.

### Motivation and Context
- SSO settings is a singleton configuration that always exists in Jamf Pro, but the resource currently declares no `Importer`, so `terraform import` fails with `resource jamfpro_sso_settings doesn't support import`.
- Without import support, the only way to bring an existing tenant's live SSO configuration under Terraform management is a create, which PUTs over the live settings rather than adopting them — risky for a setting where a bad write can lock admins out of the console.
- All eight other singleton resources (`client_checkin`, `smtp_server`, `reenrollment`, `engage_settings`, `computer_inventory_collection_settings`, `local_admin_password_settings`, `access_management_settings`, `self_service_settings`) already declare `Importer: &schema.ResourceImporter{StateContext: schema.ImportStatePassthroughContext}`; this PR applies the identical pattern.
- No CRUD changes are needed: `read` already normalizes the ID to `jamfpro_sso_settings_singleton`, so passthrough import works as-is.
- Per the example-file guidelines in the developer guide, the import command is documented in a comment in `examples/resources/jamfpro_sso_settings/resource.tf`.

### Dependencies
- None. No API, SDK, or schema changes; no configuration changes; no version updates required.

## Type of Change
Please mark the relevant option with an `x`:
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update (Wiki/README/Code comments)
- [ ] ♻️ Refactor (code improvement without functional changes)
- [ ] 🎨 Style update (formatting, renaming)
- [ ] 🔧 Configuration change
- [ ] 📦 Dependency update

## Testing
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`go test ./internal/...`, plus `go build ./...`, `go vet`, and `gofmt` all clean)
- [ ] I have added integration tests following the [testing implementation guide](../docs/testing-implementation.md)
- [x] I have tested this code in the following browsers/environments: existing integration payloads already cover this resource at `testing/payloads/jamfpro_sso_settings/`; the importer itself is the same `ImportStatePassthroughContext` used by the other eight singletons. I cannot run the sandbox integration workflow from a fork, and have not yet run a live `terraform import` against a tenant with this build.

## Quality Checklist
- [x] I have reviewed my own code before requesting review
- [x] I have verified there are no other open Pull Requests for the same update/change
- [x] All CI/CD pipelines pass without errors or warnings
- [x] My code follows the established style guidelines of this project
- [x] My comments are used only when necessary, ideally where the codes purpose is not self explanatory (eg: necessary magic numbers)
- [x] I have added necessary documentation (if appropriate)
- [x] I have made corresponding changes to the README and other relevant documentation (none needed — generated docs don't render import sections; the import command is documented in the example file)
- [x] My changes generate no new warnings

## Additional Notes
Import usage after this change:

```bash
terraform import jamfpro_sso_settings.this jamfpro_sso_settings_singleton
```

or with an import block:

```hcl
import {
  to = jamfpro_sso_settings.this
  id = "jamfpro_sso_settings_singleton"
}
```
