### PR TITLE
test: fix flaky TestSortPlistKeys assertion

### DIFF
--- a/internal/common/plist/shared_test.go
+++ b/internal/common/plist/shared_test.go
@@ -1,10 +1,15 @@
 package plist
 
 import (
+	"encoding/xml"
+	"errors"
+	"io"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSortPlistKeys(t *testing.T) {
@@ -99,21 +104,79 @@ func TestSortPlistKeys(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := SortPlistKeys(tt.input)
 			assert.Equal(t, tt.want, got, "unexpected sorted output")
-
-			// Extra check only for array-of-maps case
-			if tt.name == "Dictionary with array of dictionaries" {
-				if arr, ok := got["array"].([]any); ok {
-					for i, item := range arr {
-						if m, ok := item.(map[string]any); ok {
-							keys := make([]string, 0, len(m))
-							for k := range m {
-								keys = append(keys, k)
-							}
-							assert.True(t, sort.StringsAreSorted(keys), "map at array[%d] keys not sorted", i)
-						}
-					}
-				}
-			}
 		})
+	}
+}
+
+// assertDictKeysSorted walks an encoded plist and asserts that every <dict>
+// lists its own keys in sorted order. Sortedness is per dictionary, not global:
+// in document order a nested dict's keys are interleaved between its parent's,
+// so a flat scan of the whole document is not expected to be sorted.
+func assertDictKeysSorted(t *testing.T, encoded string) {
+	t.Helper()
+
+	dec := xml.NewDecoder(strings.NewReader(encoded))
+	var stack [][]string
+
+	for {
+		tok, err := dec.Token()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		require.NoError(t, err, "encoded plist must be well-formed XML")
+
+		switch t2 := tok.(type) {
+		case xml.StartElement:
+			switch t2.Name.Local {
+			case "dict":
+				stack = append(stack, nil)
+			case "key":
+				var name string
+				require.NoError(t, dec.DecodeElement(&name, &t2))
+				require.NotEmpty(t, stack, "<key> outside of a <dict>")
+				stack[len(stack)-1] = append(stack[len(stack)-1], name)
+			}
+		case xml.EndElement:
+			if t2.Name.Local == "dict" {
+				keys := stack[len(stack)-1]
+				stack = stack[:len(stack)-1]
+				assert.True(t, sort.StringsAreSorted(keys),
+					"dict keys must be sorted, got %v", keys)
+			}
+		}
+	}
+	assert.Empty(t, stack, "unbalanced <dict> elements")
+}
+
+// SortPlistKeys exists so that two structurally equal profiles serialise to the
+// same bytes, which is what makes payload diff suppression work. That ordering
+// is not observable on the returned map — Go randomises map iteration order, so
+// asserting over `for k := range m` is a coin flip rather than a test. It
+// becomes observable only once the map is encoded, so assert it there.
+func TestSortPlistKeysEncodesDeterministically(t *testing.T) {
+	input := map[string]any{
+		"zebra": "last",
+		"apple": "first",
+		"nested": map[string]any{
+			"inner_z": 2,
+			"inner_a": 1,
+		},
+		"array": []any{
+			map[string]any{"d": 4, "c": 3},
+			map[string]any{"b": 2, "a": 1},
+		},
+	}
+
+	first, err := EncodePlist(SortPlistKeys(input))
+	require.NoError(t, err)
+	assertDictKeysSorted(t, first)
+
+	// Repeat: one pass can look correct by luck if the maps happen to be
+	// iterated favourably. Byte-identical output across runs is the guarantee
+	// diff suppression actually relies on.
+	for i := range 20 {
+		again, err := EncodePlist(SortPlistKeys(input))
+		require.NoError(t, err)
+		require.Equal(t, first, again, "encoding must be identical on run %d", i+1)
 	}
 }


### PR DESCRIPTION
# Pull Request Description

## Summary

`TestSortPlistKeys/Dictionary_with_array_of_dictionaries` fails roughly a quarter of runs on `main`. It asserts a property that cannot hold, so it is replaced with one that can.

### Motivation and Context

The subtest collected a map's keys and asserted they came out sorted:

```go
keys := make([]string, 0, len(m))
for k := range m {
    keys = append(keys, k)
}
assert.True(t, sort.StringsAreSorted(keys), "map at array[%d] keys not sorted", i)
```

Go randomises map iteration order, so this is a coin flip rather than a test. With two keys per map and two maps in the fixture it passes about 25% of the time.

The property it was reaching for cannot hold on the value under test at all: `SortPlistKeys` returns `map[string]any`, and a Go map has no key order to assert. Ordering only becomes observable once the map is encoded — which is also where the codebase actually depends on it, since `EncodePlist` output feeds the payload diff-suppression hash comparison.

Reproduction on `main`:

```
$ for i in $(seq 1 10); do go test ./internal/common/plist/ -run TestSortPlistKeys -count=1 \
    | grep -qE "^ok" && printf "P" || printf "F"; done
PFPFPPPFPP
```

### What changed

Removed the non-deterministic assertion and added `TestSortPlistKeysEncodesDeterministically`, which:

- encodes the sorted map and asserts every `<dict>` lists **its own** keys in sorted order, walking the document with `encoding/xml`. Sortedness is checked per dictionary rather than over a flat scan, because in document order a nested dict's keys are interleaved between its parent's — a flat list is legitimately unsorted (`[apple array c d a b nested inner_a inner_z zebra]`).
- then asserts 20 further encodes are byte-identical, since a single pass can look correct by luck. Byte-identical output across runs is the guarantee diff suppression actually relies on.

The existing table-driven `assert.Equal(tt.want, got)` already covers the function's real observable contract — deep equality plus array element ordering — and is unchanged.

### Note for reviewers

This guards the serialisation pipeline rather than `SortPlistKeys` alone. `howett.net/plist` sorts dictionary keys on encode regardless, which I verified directly:

```
identical output with/without SortPlistKeys: true
```

So the key-sorting half of `SortPlistKeys` has no observable effect — not on its return value (Go maps are unordered) and not on the encoded output (howett sorts anyway). Its **array** sorting is load-bearing and remains covered by the existing table cases.

I have deliberately left production code unchanged here, since this PR is scoped to removing a flaky test. Whether the redundant key-sorting should be simplified is worth a separate look.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Testing
- [x] New and existing unit tests pass locally with my changes

40 consecutive runs of `./internal/common/plist` pass, against roughly 3 in 4 before:

```
$ for i in $(seq 1 40); do go test ./internal/common/plist/ -count=1 | grep -qE "^ok" \
    && printf "." || printf "F"; done
........................................
pass=40 fail=0
```

`go build ./...`, `go vet`, `gofmt` and `golangci-lint` clean on the changed file.

## Quality Checklist
- [x] I have reviewed my own code before requesting review
- [x] I have verified there are no other open Pull Requests for the same update/change
- [x] My code follows the established style guidelines of this project (`testify` in tests, no SPDX headers)
- [x] My changes generate no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)