### PR TITLE
ci: skip integration tests when no payload project maps to the change

### DIFF
--- a/.github/workflows/provider-integration-test.yml
+++ b/.github/workflows/provider-integration-test.yml
@@ -76,6 +76,9 @@ jobs:
         if: env.TARGETS != 'compileonly'
         working-directory: .
         run: |
+          # targets.txt is authoritative when present, including when empty:
+          # an empty file means the PR touched internal/ but no payload project
+          # maps to it, so there is nothing to integration test.
           if [ -f "targets.txt" ]; then
             targets=$(cat targets.txt)
           elif [ "$TARGETS" != "all" ] && [ ! -z "$TARGETS" ]; then
@@ -83,13 +86,19 @@ jobs:
           else
             targets="all"
           fi
-          echo $targets
           echo "targets=$targets" >> $GITHUB_OUTPUT
+          if [ -z "$targets" ]; then
+            echo "No payload projects map to this change - skipping integration tests."
+            echo "has_targets=false" >> $GITHUB_OUTPUT
+          else
+            echo "$targets"
+            echo "has_targets=true" >> $GITHUB_OUTPUT
+          fi
 
 
       - name: Generate UUID
         id: generate-uuid
-        if: env.TARGETS != 'compileonly'
+        if: env.TARGETS != 'compileonly' && steps.set-targets.outputs.has_targets != 'false'
         run: |
           generated_uuid=$(uuidgen)
           echo "uuid=$generated_uuid" >> $GITHUB_OUTPUT
@@ -98,14 +107,14 @@ jobs:
 
       - name: Populate Testing Directory
         id: generate-test-dir
-        if: env.TARGETS != 'compileonly'
+        if: env.TARGETS != 'compileonly' && steps.set-targets.outputs.has_targets != 'false'
         working-directory: .
         run: |
           python3 testing/action_scripts/generate_test_directory.py "${{ steps.set-targets.outputs.targets }}"
 
 
       - name: Build TFVARS File
-        if: env.TARGETS != 'compileonly'
+        if: env.TARGETS != 'compileonly' && steps.set-targets.outputs.has_targets != 'false'
         id: build-tfvars
         working-directory: ./testing
         run: |
@@ -121,6 +130,7 @@ jobs:
 
 
       - name: Run Tests
+        if: env.TARGETS != 'compileonly' && steps.set-targets.outputs.has_targets != 'false'
         working-directory: ./testing
         id: run-tests
         run: |
@@ -129,7 +139,7 @@ jobs:
 
 
       - name: 5s Delay to Allow Jamf API to Settle
-        if: always() && env.TARGETS != 'compileonly'
+        if: always() && env.TARGETS != 'compileonly' && steps.generate-uuid.outputs.uuid != ''
         run: sleep 5
 
 
@@ -137,10 +147,14 @@ jobs:
       # used to skip cleanup entirely. Every red run then leaked its objects
       # into the shared sandbox, and those orphans collided with the next run
       # (409 Duplicate payload uuid) — a failure loop that sustains itself.
+      #
+      # The uuid guard matters precisely because of always(): if the job fails
+      # before Generate UUID runs, there is nothing to clean and the run id
+      # would expand to an empty string, which cleanup.py rejects.
       - name: Cleanup
-        if: always() && env.TARGETS != 'compileonly'
+        if: always() && env.TARGETS != 'compileonly' && steps.generate-uuid.outputs.uuid != ''
         id: cleanup
         working-directory: ./testing
         run: |
           if [ -d "./data_sources" ]; then rm -rf ./data_sources; fi
-          python3 action_scripts/cleanup.py -r ${{ steps.generate-uuid.outputs.uuid }}
+          python3 action_scripts/cleanup.py -r "${{ steps.generate-uuid.outputs.uuid }}"

--- a/testing/action_scripts/generate_test_targets.py
+++ b/testing/action_scripts/generate_test_targets.py
@@ -31,7 +31,6 @@ Output (`targets.txt`):
   `user,group`
 '''
 
-import sys
 import argparse
 import requests
 
@@ -93,9 +92,14 @@ def main():
 
     targets = list(set(targets))
 
+    # No targets is a legitimate outcome, not an error: the workflow triggers on
+    # any change under internal/, but only internal/services/<resource>/ maps to
+    # a payload project. A change to internal/common/ or a shared helper has
+    # nothing to integration test. Write an empty targets file and let the
+    # workflow skip the test steps -- exiting non-zero here failed the job for
+    # every such PR, and writing no file at all would fall through to "all".
     if not targets:
-        print("no targets found")
-        sys.exit(1)
+        print("no targets found - no integration tests apply to this change")
 
     save_targets_to_file(targets)
 


### PR DESCRIPTION
# Pull Request Description

## Summary

Fixes two failures in the integration-test workflow that between them make any PR touching `internal/` outside `internal/services/` unmergeable.

Found while trying to land #1156 (a test-only fix in `internal/common/plist/`), which cannot go green on `main` today.

### 1. No targets is treated as an error

`generate_test_targets.py` exited `1` when it found no targets:

```python
if not targets:
    print("no targets found")
    sys.exit(1)
```

The workflow triggers on `internal/**`, but `extract_resource_from_path` only maps `internal/services/<resource>/` to a payload project. So a change to a shared helper under `internal/common/` — or any Go change outside `services/` — fails the job outright, with no way to merge it green.

No targets is a legitimate outcome, not an error. It now writes an empty `targets.txt`, exits 0, and the workflow skips the test steps.

**Why an empty file rather than no file:** `targets.txt` being *absent* already means "fall back to `$TARGETS`, else `all`". Returning early without writing would therefore run all 53 payload projects against the sandbox for a change with nothing to test — considerably worse than failing. An empty file is the explicit "nothing to test" signal, so the file is authoritative whenever it exists.

### 2. Cleanup runs with an empty run id

The `Cleanup` step passed an unquoted run id:

```yaml
python3 action_scripts/cleanup.py -r ${{ steps.generate-uuid.outputs.uuid }}
```

When the job fails before `Generate UUID`, that expands to nothing, `-r` consumes the next token, and `cleanup.py` exits 2 with `-r option requires 1 argument`.

This was latent while cleanup was skipped on failure. It became visible once cleanup became `always()` in #1125 — correctly, since skipping cleanup on failure is what was leaking orphaned profiles into the shared sandbox in the first place. The consequence was a second, confusing error stacked after the real one on every early failure.

`Cleanup` and the settle delay are now gated on the uuid actually being set, and the argument is quoted.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Testing

Simulated all four target-selection paths against the step's shell logic:

| case | result |
|---|---|
| empty `targets.txt` (shared-helper PR) | `has_targets=false` → tests skipped |
| populated `targets.txt` | `has_targets=true` → runs those targets |
| no `targets.txt`, dispatch with explicit target | `has_targets=true` → runs that target |
| no `targets.txt`, dispatch `all` | `has_targets=true` → runs all |

Also exercised `extract_resource_from_path` and `save_targets_to_file` directly:

```
(False, None)             internal/common/plist/shared_test.go
(True, '<resource>')      internal/services/<resource>/resource.go
(False, None)             docs/index.md

empty targets -> targets.txt exists: True, contents: ''
```

Workflow YAML parses and every `if:` gate is as intended. `pylint` gate passes (9.14, threshold 9).

The real proof is #1156 going green once this lands — it is currently red solely because of item 1.

## Quality Checklist
- [x] I have reviewed my own code before requesting review
- [x] I have verified there are no other open Pull Requests for the same update/change
- [x] My changes generate no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)